### PR TITLE
Add a lower bound on haskell-lsp (we are incompatible with 0.14)

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -38,7 +38,7 @@ library
         ghc >= 8.4,
         hashable,
         haskell-lsp-types,
-        haskell-lsp,
+        haskell-lsp >= 0.15,
         mtl,
         network-uri,
         prettyprinter-ansi-terminal,


### PR DESCRIPTION
Otherwise I get build failures