### PR TITLE
Don't hide Shake functions we don't conflict with

### DIFF
--- a/src/Development/IDE/Core/OfInterest.hs
+++ b/src/Development/IDE/Core/OfInterest.hs
@@ -27,7 +27,7 @@ import           Data.Set                                 (Set)
 import qualified Data.Set                                 as Set
 import qualified Data.Text as T
 import Data.Tuple.Extra
-import           Development.Shake                        hiding (Diagnostic, Env)
+import           Development.Shake
 
 import           Development.IDE.Core.Shake
 

--- a/src/Development/IDE/Core/OfInterest.hs
+++ b/src/Development/IDE/Core/OfInterest.hs
@@ -27,7 +27,7 @@ import           Data.Set                                 (Set)
 import qualified Data.Set                                 as Set
 import qualified Data.Text as T
 import Data.Tuple.Extra
-import           Development.Shake                        hiding (Diagnostic, Env, newCache)
+import           Development.Shake                        hiding (Diagnostic, Env)
 
 import           Development.IDE.Core.Shake
 

--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -17,7 +17,7 @@ import Development.IDE.Types.Location
 import           Data.Hashable
 import           Data.Typeable
 import qualified Data.Set as S
-import           Development.Shake                        hiding (Env, newCache)
+import           Development.Shake                        hiding (Env)
 import           GHC.Generics                             (Generic)
 
 import           GHC

--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -17,7 +17,7 @@ import Development.IDE.Types.Location
 import           Data.Hashable
 import           Data.Typeable
 import qualified Data.Set as S
-import           Development.Shake                        hiding (Env)
+import           Development.Shake
 import           GHC.Generics                             (Generic)
 
 import           GHC

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -46,7 +46,7 @@ import Data.List
 import qualified Data.Set                                 as Set
 import qualified Data.Text                                as T
 import           Development.IDE.GHC.Error
-import           Development.Shake                        hiding (Diagnostic, Env, newCache)
+import           Development.Shake                        hiding (Diagnostic, Env)
 import Development.IDE.Core.RuleTypes
 
 import           GHC hiding (parseModule, typecheckModule)

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -46,7 +46,7 @@ import Data.List
 import qualified Data.Set                                 as Set
 import qualified Data.Text                                as T
 import           Development.IDE.GHC.Error
-import           Development.Shake                        hiding (Diagnostic, Env)
+import           Development.Shake                        hiding (Diagnostic)
 import Development.IDE.Core.RuleTypes
 
 import           GHC hiding (parseModule, typecheckModule)

--- a/src/Development/IDE/Core/Service.hs
+++ b/src/Development/IDE/Core/Service.hs
@@ -25,7 +25,7 @@ import Development.IDE.Types.Options (IdeOptions(..))
 import           Development.IDE.Core.FileStore
 import           Development.IDE.Core.OfInterest
 import Development.IDE.Types.Logger
-import           Development.Shake                        hiding (Diagnostic, Env, newCache)
+import           Development.Shake                        hiding (Diagnostic, Env)
 import Data.Either.Extra
 import qualified Language.Haskell.LSP.Messages as LSP
 

--- a/src/Development/IDE/Core/Service.hs
+++ b/src/Development/IDE/Core/Service.hs
@@ -25,7 +25,7 @@ import Development.IDE.Types.Options (IdeOptions(..))
 import           Development.IDE.Core.FileStore
 import           Development.IDE.Core.OfInterest
 import Development.IDE.Types.Logger
-import           Development.Shake                        hiding (Diagnostic, Env)
+import           Development.Shake
 import Data.Either.Extra
 import qualified Language.Haskell.LSP.Messages as LSP
 


### PR DESCRIPTION
At some point we had our own versions of newCache and Env in ghcide. We don't now, so a lot of the hidings don't make sense.