### PR TITLE
Add a .ghci file

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,0 +1,23 @@
+:set -Wunused-binds -Wunused-imports -Worphans -Wunused-matches -Wincomplete-patterns
+
+:set -XBangPatterns
+:set -XDeriveFunctor
+:set -XDeriveGeneric
+:set -XGeneralizedNewtypeDeriving
+:set -XLambdaCase
+:set -XNamedFieldPuns
+:set -XOverloadedStrings
+:set -XRecordWildCards
+:set -XScopedTypeVariables
+:set -XStandaloneDeriving
+:set -XTupleSections
+:set -XTypeApplications
+:set -XViewPatterns
+
+:set -package=ghc
+:set -hide-package=ghc-lib-parser
+:set -DGHC_STABLE
+:set -isrc
+:set -iexe
+
+:load Main


### PR DESCRIPTION
This file got removed when the project got renamed from hie-core to ghcide, before it got transferred to this repo. I find this file useful for invoking ghcid on ghcide, and also directly running ghci.