### PR TITLE
Add code action for fixing misspelled variable names

### DIFF
--- a/src/Development/IDE/GHC/Util.hs
+++ b/src/Development/IDE/GHC/Util.hs
@@ -72,7 +72,7 @@ runGhcEnv :: HscEnv -> Ghc a -> IO a
 runGhcEnv env act = do
     filesToClean <- newIORef emptyFilesToClean
     dirsToClean <- newIORef mempty
-    let dflags = (hsc_dflags env){filesToClean=filesToClean, dirsToClean=dirsToClean}
+    let dflags = (hsc_dflags env){filesToClean=filesToClean, dirsToClean=dirsToClean, useUnicode=True}
     ref <- newIORef env{hsc_dflags=dflags}
     unGhc act (Session ref) `finally` do
         cleanTempFiles dflags


### PR DESCRIPTION
The suggestions are extracted from GHC's error messages.

To make parsing these error messages easier, we set the flag
useUnicode=True, which makes GHC always use “smart quotes”.

(This is a port of the pull request https://github.com/digital-asset/daml/pull/2809 to the new repo.)