### PR TITLE
Add preprocessor module

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -99,6 +99,7 @@ library
     other-modules:
         Development.IDE.Core.Debouncer
         Development.IDE.Core.Compile
+        Development.IDE.Core.Preprocessor
         Development.IDE.GHC.Compat
         Development.IDE.GHC.CPP
         Development.IDE.GHC.Error

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -272,7 +272,7 @@ parseFileContents
        -> FilePath  -- ^ the filename (for source locations)
        -> Maybe SB.StringBuffer -- ^ Haskell module source text (full Unicode is supported)
        -> ExceptT [FileDiagnostic] m ([FileDiagnostic], ParsedModule)
-parseFileContents preprocessor filename mbContents = do
+parseFileContents sourcePlugin filename mbContents = do
    let loc  = mkRealSrcLoc (mkFastString filename) 1 1
    contents <- liftIO $ maybe (hGetStringBuffer filename) return mbContents
    let isOnDisk = isNothing mbContents
@@ -318,7 +318,7 @@ parseFileContents preprocessor filename mbContents = do
                  throwE $ diagFromErrMsgs "parser" dflags $ snd $ getMessages pst dflags
 
                -- Ok, we got here. It's safe to continue.
-               let (errs, parsed) = preprocessor rdr_module
+               let (errs, parsed) = sourcePlugin rdr_module
                unless (null errs) $ throwE $ diagFromStrings "parser" errs
                ms <- getModSummaryFromBuffer filename contents dflags parsed
                let pm =

--- a/src/Development/IDE/Core/Preprocessor.hs
+++ b/src/Development/IDE/Core/Preprocessor.hs
@@ -1,9 +1,6 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE CPP #-}
-
 module Development.IDE.Core.Preprocessor
   ( preprocessor
   ) where
@@ -70,7 +67,6 @@ parsePragmasIntoDynFlags fp contents = catchSrcErrors "pragmas" $ do
     return dflags
 
 
-
 -- | Run (unlit) literate haskell preprocessor on a file, or buffer if set
 runLhs :: DynFlags -> FilePath -> Maybe SB.StringBuffer -> IO SB.StringBuffer
 runLhs dflags filename contents = withTempDir $ \dir -> do
@@ -97,6 +93,7 @@ runLhs dflags filename contents = withTempDir $ \dir -> do
     escape ('\'':cs) = '\\':'\'': escape cs
     escape (c:cs)    = c : escape cs
     escape []        = []
+
 
 -- | Run CPP on a file
 runCpp :: DynFlags -> FilePath -> Maybe SB.StringBuffer -> IO SB.StringBuffer

--- a/src/Development/IDE/Core/Preprocessor.hs
+++ b/src/Development/IDE/Core/Preprocessor.hs
@@ -1,0 +1,90 @@
+-- Copyright (c) 2019 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE CPP #-}
+
+-- | Based on https://ghc.haskell.org/trac/ghc/wiki/Commentary/Compiler/API.
+--   Given a list of paths to find libraries, and a file to compile, produce a list of 'CoreModule' values.
+module Development.IDE.Core.Preprocessor
+  ( runLhs
+  , runCpp
+  ) where
+
+import Development.IDE.GHC.CPP
+import Development.IDE.GHC.Orphans()
+import Development.IDE.GHC.Compat
+import GHC
+import           GhcMonad
+import           StringBuffer                   as SB
+
+import           Data.List.Extra
+import           System.FilePath
+import System.IO.Extra
+import Data.Char
+
+import SysTools (Option (..), runUnlit)
+
+-- | Run (unlit) literate haskell preprocessor on a file, or buffer if set
+runLhs :: DynFlags -> FilePath -> Maybe SB.StringBuffer -> IO SB.StringBuffer
+runLhs dflags filename contents = withTempDir $ \dir -> do
+    let fout = dir </> takeFileName filename <.> "unlit"
+    filesrc <- case contents of
+        Nothing   -> return filename
+        Just cnts -> do
+            let fsrc = dir </> takeFileName filename <.> "literate"
+            withBinaryFile fsrc WriteMode $ \h ->
+                hPutStringBuffer h cnts
+            return fsrc
+    unlit filesrc fout
+    SB.hGetStringBuffer fout
+  where
+    unlit filein fileout = SysTools.runUnlit dflags (args filein fileout)
+    args filein fileout = [
+                      SysTools.Option     "-h"
+                    , SysTools.Option     (escape filename) -- name this file
+                    , SysTools.FileOption "" filein       -- input file
+                    , SysTools.FileOption "" fileout ]    -- output file
+    -- taken from ghc's DriverPipeline.hs
+    escape ('\\':cs) = '\\':'\\': escape cs
+    escape ('\"':cs) = '\\':'\"': escape cs
+    escape ('\'':cs) = '\\':'\'': escape cs
+    escape (c:cs)    = c : escape cs
+    escape []        = []
+
+-- | Run CPP on a file
+runCpp :: DynFlags -> FilePath -> Maybe SB.StringBuffer -> IO SB.StringBuffer
+runCpp dflags filename contents = withTempDir $ \dir -> do
+    let out = dir </> takeFileName filename <.> "out"
+    case contents of
+        Nothing -> do
+            -- Happy case, file is not modified, so run CPP on it in-place
+            -- which also makes things like relative #include files work
+            -- and means location information is correct
+            doCpp dflags True filename out
+            liftIO $ SB.hGetStringBuffer out
+
+        Just contents -> do
+            -- Sad path, we have to create a version of the path in a temp dir
+            -- __FILE__ macro is wrong, ignoring that for now (likely not a real issue)
+
+            -- Relative includes aren't going to work, so we fix that by adding to the include path.
+            dflags <- return $ addIncludePathsQuote (takeDirectory filename) dflags
+
+            -- Location information is wrong, so we fix that by patching it afterwards.
+            let inp = dir </> "___GHCIDE_MAGIC___"
+            withBinaryFile inp WriteMode $ \h ->
+                hPutStringBuffer h contents
+            doCpp dflags True inp out
+
+            -- Fix up the filename in lines like:
+            -- # 1 "C:/Temp/extra-dir-914611385186/___GHCIDE_MAGIC___"
+            let tweak x
+                    | Just x <- stripPrefix "# " x
+                    , "___GHCIDE_MAGIC___" `isInfixOf` x
+                    , let num = takeWhile (not . isSpace) x
+                    -- important to use /, and never \ for paths, even on Windows, since then C escapes them
+                    -- and GHC gets all confused
+                        = "# " <> num <> " \"" <> map (\x -> if isPathSeparator x then '/' else x) filename <> "\""
+                    | otherwise = x
+            stringToStringBuffer . unlines . map tweak . lines <$> readFileUTF8' out

--- a/src/Development/IDE/Core/Preprocessor.hs
+++ b/src/Development/IDE/Core/Preprocessor.hs
@@ -33,21 +33,21 @@ import Data.Maybe
 --   e.g. unlit/cpp. Return the resulting buffer and the DynFlags it implies.
 preprocessor :: GhcMonad m => FilePath -> Maybe StringBuffer -> ExceptT [FileDiagnostic] m (StringBuffer, DynFlags)
 preprocessor filename mbContents = do
-   -- Perform unlit
-   (isOnDisk, contents) <- if isLiterate filename then do
+    -- Perform unlit
+    (isOnDisk, contents) <- if isLiterate filename then do
         dflags <- getDynFlags
         newcontent <- liftIO $ runLhs dflags filename mbContents
         return (False, newcontent)
-   else do
-      contents <- liftIO $ maybe (hGetStringBuffer filename) return mbContents
-      let isOnDisk = isNothing mbContents
-      return (isOnDisk, contents)
+    else do
+        contents <- liftIO $ maybe (hGetStringBuffer filename) return mbContents
+        let isOnDisk = isNothing mbContents
+        return (isOnDisk, contents)
 
-   -- Perform cpp
-   dflags  <- ExceptT $ parsePragmasIntoDynFlags filename contents
-   if not $ xopt LangExt.Cpp dflags then
+    -- Perform cpp
+    dflags  <- ExceptT $ parsePragmasIntoDynFlags filename contents
+    if not $ xopt LangExt.Cpp dflags then
         return (contents, dflags)
-   else do
+    else do
         contents <- liftIO $ runCpp dflags filename $ if isOnDisk then Nothing else Just contents
         dflags <- ExceptT $ parsePragmasIntoDynFlags filename contents
         return (contents, dflags)

--- a/src/Development/IDE/Core/Preprocessor.hs
+++ b/src/Development/IDE/Core/Preprocessor.hs
@@ -12,15 +12,15 @@ import Development.IDE.GHC.CPP
 import Development.IDE.GHC.Orphans()
 import Development.IDE.GHC.Compat
 import GHC
-import           GhcMonad
-import           StringBuffer                   as SB
+import GhcMonad
+import StringBuffer as SB
 
-import           Data.List.Extra
-import           System.FilePath
+import Data.List.Extra
+import System.FilePath
 import System.IO.Extra
 import Data.Char
 import DynFlags
-import qualified HeaderInfo                     as Hdr
+import qualified HeaderInfo as Hdr
 import Development.IDE.Types.Diagnostics
 import Development.IDE.GHC.Error
 import SysTools (Option (..), runUnlit)

--- a/src/Development/IDE/Core/Preprocessor.hs
+++ b/src/Development/IDE/Core/Preprocessor.hs
@@ -33,17 +33,17 @@ import Data.Maybe
 --   e.g. unlit/cpp. Return the resulting buffer and the DynFlags it implies.
 preprocessor :: GhcMonad m => FilePath -> Maybe StringBuffer -> ExceptT [FileDiagnostic] m (StringBuffer, DynFlags)
 preprocessor filename mbContents = do
-   contents <- liftIO $ maybe (hGetStringBuffer filename) return mbContents
-   let isOnDisk = isNothing mbContents
-
-   -- unlit content if literate Haskell ending
-   (isOnDisk, contents) <- if isLiterate  filename
-      then do
+   -- Perform unlit
+   (isOnDisk, contents) <- if isLiterate filename then do
         dflags <- getDynFlags
         newcontent <- liftIO $ runLhs dflags filename mbContents
         return (False, newcontent)
-      else return (isOnDisk, contents)
+   else do
+      contents <- liftIO $ maybe (hGetStringBuffer filename) return mbContents
+      let isOnDisk = isNothing mbContents
+      return (isOnDisk, contents)
 
+   -- Perform cpp
    dflags  <- ExceptT $ parsePragmasIntoDynFlags filename contents
    if not $ xopt LangExt.Cpp dflags then
         return (contents, dflags)

--- a/src/Development/IDE/Core/Preprocessor.hs
+++ b/src/Development/IDE/Core/Preprocessor.hs
@@ -37,7 +37,7 @@ preprocessor filename mbContents = do
    let isOnDisk = isNothing mbContents
 
    -- unlit content if literate Haskell ending
-   (isOnDisk, contents) <- if ".lhs" `isSuffixOf` filename
+   (isOnDisk, contents) <- if isLiterate  filename
       then do
         dflags <- getDynFlags
         newcontent <- liftIO $ runLhs dflags filename mbContents
@@ -51,6 +51,10 @@ preprocessor filename mbContents = do
         contents <- liftIO $ runCpp dflags filename $ if isOnDisk then Nothing else Just contents
         dflags <- ExceptT $ parsePragmasIntoDynFlags filename contents
         return (contents, dflags)
+
+
+isLiterate :: FilePath -> Bool
+isLiterate x = takeExtension x `elem` [".lhs",".lhs-boot"]
 
 
 -- | This reads the pragma information directly from the provided buffer.


### PR DESCRIPTION
A non-functional refactoring. There are three preprocessor stages - unlit, cpphs and running custom -fpgm preprocessors (which I'm sure we'll do eventually). They have a nice segregated interface from the rest of the parser, so make sense to live entirely on their own, in their own module, which I've done. I'm also aware that GHC 8.10 exposes more preprocessor stuff, and that we might be able to switch to it at a future date based on runPhase. As such, having the "ideal" interface lets interested parties (e.g. @DanielG) see what we'd like it to be, and what we'd like it to do, clearly.

I did make it work for `.lhs-boot` files and optimised Literate Haskell but neither of those are very interested.