### PR TITLE
Defer type errors

### DIFF
--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -145,9 +145,10 @@ demoteTypeErrorsToWarnings =
     pm{pm_mod_summary = up $ pm_mod_summary pm}
 
 unDefer :: (WarnReason, FileDiagnostic) -> FileDiagnostic
-unDefer (Reason Opt_WarnDeferredTypeErrors, fd) = upgradeWarningToError fd
-unDefer (Reason Opt_WarnTypedHoles        , fd) = upgradeWarningToError fd
-unDefer (                                _, fd) = fd
+unDefer (Reason Opt_WarnDeferredTypeErrors         , fd) = upgradeWarningToError fd
+unDefer (Reason Opt_WarnTypedHoles                 , fd) = upgradeWarningToError fd
+unDefer (Reason Opt_WarnDeferredOutOfScopeVariables, fd) = upgradeWarningToError fd
+unDefer ( _                                        , fd) = fd
 
 upgradeWarningToError :: FileDiagnostic -> FileDiagnostic
 upgradeWarningToError (nfp, fd) = (nfp, fd{_severity = Just DsError})

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -135,6 +135,7 @@ demoteTypeErrorsToWarnings =
   demoteTEsToWarns :: DynFlags -> DynFlags
   demoteTEsToWarns = (`gopt_set` Opt_DeferTypeErrors)
                    . (`gopt_set` Opt_DeferTypedHoles)
+                   . (`gopt_set` Opt_DeferOutOfScopeVariables)
 
   update_hspp_opts :: (DynFlags -> DynFlags) -> ModSummary -> ModSummary
   update_hspp_opts up ms = ms{ms_hspp_opts = up $ ms_hspp_opts ms}

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -134,6 +134,7 @@ demoteTypeErrorsToWarnings =
 
   demoteTEsToWarns :: DynFlags -> DynFlags
   demoteTEsToWarns = (`gopt_set` Opt_DeferTypeErrors)
+                   . (`gopt_set` Opt_DeferTypedHoles)
 
   update_hspp_opts :: (DynFlags -> DynFlags) -> ModSummary -> ModSummary
   update_hspp_opts up ms = ms{ms_hspp_opts = up $ ms_hspp_opts ms}

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -82,12 +82,12 @@ computePackageDeps env pkg = do
 
 -- | Typecheck a single module using the supplied dependencies and packages.
 typecheckModule
-    :: Bool
+    :: IdeDefer
     -> HscEnv
     -> [TcModuleResult]
     -> ParsedModule
     -> IO ([FileDiagnostic], Maybe TcModuleResult)
-typecheckModule defer packageState deps pm =
+typecheckModule (IdeDefer defer) packageState deps pm =
     let demoteIfDefer = if defer then demoteTypeErrorsToWarnings else id
     in
     fmap (either (, Nothing) (second Just)) $

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -133,8 +133,7 @@ demoteTypeErrorsToWarnings =
   (update_pm_mod_summary . update_hspp_opts) demoteTEsToWarns where
 
   demoteTEsToWarns :: DynFlags -> DynFlags
-  demoteTEsToWarns = (`wopt_set` Opt_WarnDeferredTypeErrors)
-                   . (`gopt_set` Opt_DeferTypeErrors)
+  demoteTEsToWarns = (`gopt_set` Opt_DeferTypeErrors)
 
   update_hspp_opts :: (DynFlags -> DynFlags) -> ModSummary -> ModSummary
   update_hspp_opts up ms = ms{ms_hspp_opts = up $ ms_hspp_opts ms}

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -312,7 +312,8 @@ typeCheckRule =
         tms <- uses_ TypeCheck (transitiveModuleDeps deps)
         setPriority priorityTypeCheck
         packageState <- hscEnv <$> use_ GhcSession file
-        liftIO $ typecheckModule packageState tms pm
+        IdeOptions{ optDefer = defer} <- getIdeOptions
+        liftIO $ typecheckModule defer packageState tms pm
 
 
 generateCoreRule :: Rules ()

--- a/src/Development/IDE/Types/Options.hs
+++ b/src/Development/IDE/Types/Options.hs
@@ -44,6 +44,8 @@ data IdeOptions = IdeOptions
     -- ^ the ```language to use
   , optNewColonConvention :: Bool
     -- ^ whether to use new colon convention
+  , optDefer :: Bool
+    -- ^ whether to defer type errors, typed holes and out of scope variables.
   }
 
 newtype IdeReportProgress = IdeReportProgress Bool
@@ -63,6 +65,7 @@ defaultIdeOptions session = IdeOptions
     ,optReportProgress = IdeReportProgress False
     ,optLanguageSyntax = "haskell"
     ,optNewColonConvention = False
+    ,optDefer = True
     }
 
 

--- a/src/Development/IDE/Types/Options.hs
+++ b/src/Development/IDE/Types/Options.hs
@@ -7,6 +7,7 @@
 module Development.IDE.Types.Options
   ( IdeOptions(..)
   , IdeReportProgress(..)
+  , IdeDefer(..)
   , clientSupportsProgress
   , IdePkgLocationOptions(..)
   , defaultIdeOptions
@@ -44,7 +45,7 @@ data IdeOptions = IdeOptions
     -- ^ the ```language to use
   , optNewColonConvention :: Bool
     -- ^ whether to use new colon convention
-  , optDefer :: Bool
+  , optDefer :: IdeDefer
     -- ^ Whether to defer type errors, typed holes and out of scope
     --   variables. Deferral allows the IDE to continue to provide
     --   features such as diagnostics and go-to-definition, in
@@ -53,6 +54,7 @@ data IdeOptions = IdeOptions
   }
 
 newtype IdeReportProgress = IdeReportProgress Bool
+newtype IdeDefer          = IdeDefer          Bool
 
 clientSupportsProgress :: LSP.ClientCapabilities -> IdeReportProgress
 clientSupportsProgress caps = IdeReportProgress $ fromMaybe False $
@@ -69,7 +71,7 @@ defaultIdeOptions session = IdeOptions
     ,optReportProgress = IdeReportProgress False
     ,optLanguageSyntax = "haskell"
     ,optNewColonConvention = False
-    ,optDefer = True
+    ,optDefer = IdeDefer True
     }
 
 

--- a/src/Development/IDE/Types/Options.hs
+++ b/src/Development/IDE/Types/Options.hs
@@ -45,7 +45,11 @@ data IdeOptions = IdeOptions
   , optNewColonConvention :: Bool
     -- ^ whether to use new colon convention
   , optDefer :: Bool
-    -- ^ whether to defer type errors, typed holes and out of scope variables.
+    -- ^ Whether to defer type errors, typed holes and out of scope
+    --   variables. Deferral allows the IDE to continue to provide
+    --   features such as diagnostics and go-to-definition, in
+    --   situations in which they would become unavailable because of
+    --   the presence of type errors, holes or unbound variables.
   }
 
 newtype IdeReportProgress = IdeReportProgress Bool

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -94,7 +94,7 @@ diagnosticTests = testGroup "diagnostics"
       _ <- openDoc' "Testing.hs" "haskell" content
       expectDiagnostics
         [ ( "Testing.hs"
-          , [(DsWarning, (2, 8), "Found hole: _ :: Int -> String")]
+          , [(DsError, (2, 8), "Found hole: _ :: Int -> String")]
           )
         ]
   , testSession "remove required module" $ do

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -68,8 +68,8 @@ diagnosticTests = testGroup "diagnostics"
       _ <- openDoc' "Testing.hs" "haskell" content
       expectDiagnostics
         [ ( "Testing.hs"
-          , [ (DsError, (2, 14), "Variable not in scope: ab")
-            , (DsError, (4, 10), "Variable not in scope: cd")
+          , [ (DsWarning, (2, 14), "Variable not in scope: ab")
+            , (DsWarning, (4, 10), "Variable not in scope: cd")
             ]
           )
         ]

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -82,7 +82,7 @@ diagnosticTests = testGroup "diagnostics"
       _ <- openDoc' "Testing.hs" "haskell" content
       expectDiagnostics
         [ ( "Testing.hs"
-          , [(DsError, (2, 14), "Couldn't match type '[Char]' with 'Int'")]
+          , [(DsWarning, (2, 14), "Couldn't match type '[Char]' with 'Int'")]
           )
         ]
   , testSession "remove required module" $ do

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -85,6 +85,18 @@ diagnosticTests = testGroup "diagnostics"
           , [(DsError, (2, 14), "Couldn't match type '[Char]' with 'Int'")]
           )
         ]
+  , testSession "typed hole" $ do
+      let content = T.unlines
+            [ "module Testing where"
+            , "foo :: Int -> String"
+            , "foo a = _ a"
+            ]
+      _ <- openDoc' "Testing.hs" "haskell" content
+      expectDiagnostics
+        [ ( "Testing.hs"
+          , [(DsError, (2, 8), "Found hole: _ :: Int -> String")]
+          )
+        ]
   , testSession "remove required module" $ do
       let contentA = T.unlines [ "module ModuleA where" ]
       docA <- openDoc' "ModuleA.hs" "haskell" contentA

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -68,8 +68,8 @@ diagnosticTests = testGroup "diagnostics"
       _ <- openDoc' "Testing.hs" "haskell" content
       expectDiagnostics
         [ ( "Testing.hs"
-          , [ (DsWarning, (2, 14), "Variable not in scope: ab")
-            , (DsWarning, (4, 10), "Variable not in scope: cd")
+          , [ (DsError, (2, 14), "Variable not in scope: ab")
+            , (DsError, (4, 10), "Variable not in scope: cd")
             ]
           )
         ]

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -97,6 +97,31 @@ diagnosticTests = testGroup "diagnostics"
           , [(DsError, (2, 8), "Found hole: _ :: Int -> String")]
           )
         ]
+
+  , testGroup "deferral" $
+    let sourceA a = T.unlines
+          [ "module A where"
+          , "a :: Int"
+          , "a = " <> a]
+        sourceB = T.unlines
+          [ "module B where"
+          , "import A"
+          , "b :: Float"
+          , "b = True"]
+        bMessage = "Couldn't match expected type 'Float' with actual type 'Bool'"
+        expectedDs aMessage =
+          [ ("A.hs", [(DsError, (2,4), aMessage)])
+          , ("B.hs", [(DsError, (3,4), bMessage)])]
+        deferralTest title binding message = testSession title $ do
+          _ <- openDoc' "A.hs" "haskell" $ sourceA binding
+          _ <- openDoc' "B.hs" "haskell"   sourceB
+          expectDiagnostics $ expectedDs message
+    in
+    [ deferralTest "type error"       "True"    "Couldn't match expected type"
+    , deferralTest "typed hole"       "_"       "Found hole"
+    , deferralTest "out of scope var" "unbound" "Variable not in scope"
+    ]
+
   , testSession "remove required module" $ do
       let contentA = T.unlines [ "module ModuleA where" ]
       docA <- openDoc' "ModuleA.hs" "haskell" contentA

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -94,7 +94,7 @@ diagnosticTests = testGroup "diagnostics"
       _ <- openDoc' "Testing.hs" "haskell" content
       expectDiagnostics
         [ ( "Testing.hs"
-          , [(DsError, (2, 8), "Found hole: _ :: Int -> String")]
+          , [(DsWarning, (2, 8), "Found hole: _ :: Int -> String")]
           )
         ]
   , testSession "remove required module" $ do

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -82,7 +82,7 @@ diagnosticTests = testGroup "diagnostics"
       _ <- openDoc' "Testing.hs" "haskell" content
       expectDiagnostics
         [ ( "Testing.hs"
-          , [(DsWarning, (2, 14), "Couldn't match type '[Char]' with 'Int'")]
+          , [(DsError, (2, 14), "Couldn't match type '[Char]' with 'Int'")]
           )
         ]
   , testSession "remove required module" $ do


### PR DESCRIPTION
At present, all sorts of useful IDE featrues, such as diagnostics reporting and go-to-definition, stop working at the first sign of a type error. This PR attempts to fix this. The plan is:

+ defer type errors
+ report them as warnings during typechecking
+ re-upgrade them to errors after type checking

TODO:

- [x] (EDIT: fixed by #59) ~~The current implementation breaks old behaviour by changing the text of type error messages to contain fully qualified type names, e.g: `GHC.Types.Int` appears instead of `Int`.~~
- [x] There are other things besides type errors that could be deferred?
    - [x] Type Errors
    - [x] Typed Holes
    - [x] Out of scope variables