### PR TITLE
Delete non-ghcide options from coc.nvim example

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,14 +151,7 @@ Add this to your coc-settings.json (which you can edit with :CocConfig):
         "hs",
         "lhs",
         "haskell"
-      ],
-      "initializationOptions": {
-        "languageServerHaskell": {
-          "hlintOn": true,
-          "maxNumberOfProblems": 10,
-          "completionSnippetsOn": true
-        }
-      }
+      ]
     }
   }
 }


### PR DESCRIPTION
These options don‘t work with ghcide as far as I can tell. I believe they stem from copying the config used for hie-wrapper. As ghcide does not support hlint yet I believe this infos to be misleading. That‘s why I suggest deleting it.