### PR TITLE
Code actions for filling typed holes

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -81,7 +81,9 @@
     - Development.IDE.GHC.Compat
     - Development.IDE.GHC.Util
     - Development.IDE.Import.FindImports
+    - Development.IDE.LSP.CodeAction
     - Development.IDE.Spans.Calculate
+    - Main
 
 - flags:
   - default: false

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -171,6 +171,14 @@ test-suite ghcide-tests
         containers,
         extra,
         filepath,
+        --------------------------------------------------------------
+        -- The MIN_GHC_API_VERSION macro relies on MIN_VERSION pragmas
+        -- which require depending on ghc. So the tests need to depend
+        -- on ghc if they need to use MIN_GHC_API_VERSION. Maybe a
+        -- better solution can be found, but this is a quick solution
+        -- which works for now.
+        ghc,
+        --------------------------------------------------------------
         haskell-lsp-types,
         lens,
         lsp-test,
@@ -179,6 +187,7 @@ test-suite ghcide-tests
         tasty-hunit,
         text
     hs-source-dirs: test/cabal test/exe test/src
+    include-dirs: include
     ghc-options: -threaded
     main-is: Main.hs
     other-modules:

--- a/src/Development/IDE/LSP/CodeAction.hs
+++ b/src/Development/IDE/LSP/CodeAction.hs
@@ -132,7 +132,8 @@ suggestAction contents Diagnostic{_range=_range@Range{..},..}
     | "Valid hole fits include" `T.isInfixOf` _message = let
       findSuggestedHoleFits :: T.Text -> [T.Text]
       findSuggestedHoleFits = extractFitNames . selectLinesWithFits . dropPreceding . T.lines
-      proposeHoleFit name = ("replace hole with " <> name, [TextEdit _range name])
+      proposeHoleFit name = ("replace hole `" <> holeName <>  "` with " <> name, [TextEdit _range name])
+      holeName = T.strip $ last $ T.splitOn ":" $ head . T.splitOn "::" $ head $ filter ("Found hole" `T.isInfixOf`) $ T.lines _message
       dropPreceding       = dropWhile (not . ("Valid hole fits include" `T.isInfixOf`))
       selectLinesWithFits = filter ("::" `T.isInfixOf`)
       extractFitNames     = map (T.strip . head . T.splitOn " :: ")

--- a/src/Development/IDE/LSP/CodeAction.hs
+++ b/src/Development/IDE/LSP/CodeAction.hs
@@ -2,6 +2,8 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE CPP #-}
+#include "ghc-api-version.h"
 
 -- | Go to the definition of a variable.
 module Development.IDE.LSP.CodeAction
@@ -22,8 +24,6 @@ import Data.Char
 import Data.Maybe
 import Data.List.Extra
 import qualified Data.Text as T
-import Data.Version
-import System.Info
 
 -- | Generate code actions.
 codeAction
@@ -143,9 +143,12 @@ suggestAction contents Diagnostic{_range=_range@Range{..},..}
 
 suggestAction _ _ = []
 
-topOfHoleFitsMarker = if versionBranch compilerVersion >= [8,6]
-                      then "Valid hole fits include"
-                      else "Valid substitutions include"
+topOfHoleFitsMarker =
+#if MIN_GHC_API_VERSION(8,6,0)
+  "Valid hole fits include"
+#else
+  "Valid substitutions include"
+#endif
 
 mkRenameEdit :: Maybe T.Text -> Range -> T.Text -> TextEdit
 mkRenameEdit contents range name =

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -15,6 +15,8 @@ import Language.Haskell.LSP.Types
 import Language.Haskell.LSP.Types.Capabilities
 import System.Environment.Blank (setEnv)
 import System.IO.Extra
+import System.Info
+import Data.Version
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -493,7 +495,7 @@ fillTypedHoleTests = let
     , title == actionTitle ]
 
   in
-  testGroup "fill typed holes"
+  testGroup "fill typed holes" $
   [ check "replace hole `_` with show"
           "_"    "n" "n"
           "show" "n" "n"
@@ -502,10 +504,6 @@ fillTypedHoleTests = let
           "_"             "n" "n"
           "globalConvert" "n" "n"
 
-  , check "replace hole `_convertme` with localConvert"
-          "_convertme"   "n" "n"
-          "localConvert" "n" "n"
-
   , check "replace hole `_b` with globalInt"
           "_a" "_b"        "_c"
           "_a" "globalInt" "_c"
@@ -513,10 +511,14 @@ fillTypedHoleTests = let
   , check "replace hole `_c` with globalInt"
           "_a" "_b"        "_c"
           "_a" "_b" "globalInt"
+  ] <> if versionBranch compilerVersion < [8,6] then [] else
+  [ check "replace hole `_convertme` with localConvert"
+          "_convertme"   "n" "n"
+          "localConvert" "n" "n"
 
-  , check "replace hole `_c` with n"
+  , check "replace hole `_c` with parameterInt"
           "_a" "_b" "_c"
-          "_a" "_b"  "n"
+          "_a" "_b"  "parameterInt"
   ]
 
 ----------------------------------------------------------------------

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2,6 +2,8 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE CPP #-}
+#include "ghc-api-version.h"
 
 module Main (main) where
 
@@ -15,8 +17,6 @@ import Language.Haskell.LSP.Types
 import Language.Haskell.LSP.Types.Capabilities
 import System.Environment.Blank (setEnv)
 import System.IO.Extra
-import System.Info
-import Data.Version
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -495,7 +495,7 @@ fillTypedHoleTests = let
     , title == actionTitle ]
 
   in
-  testGroup "fill typed holes" $
+  testGroup "fill typed holes"
   [ check "replace hole `_` with show"
           "_"    "n" "n"
           "show" "n" "n"
@@ -504,6 +504,12 @@ fillTypedHoleTests = let
           "_"             "n" "n"
           "globalConvert" "n" "n"
 
+#if MIN_GHC_API_VERSION(8,6,0)
+  , check "replace hole `_convertme` with localConvert"
+          "_convertme"   "n" "n"
+          "localConvert" "n" "n"
+#endif
+
   , check "replace hole `_b` with globalInt"
           "_a" "_b"        "_c"
           "_a" "globalInt" "_c"
@@ -511,14 +517,12 @@ fillTypedHoleTests = let
   , check "replace hole `_c` with globalInt"
           "_a" "_b"        "_c"
           "_a" "_b" "globalInt"
-  ] <> if versionBranch compilerVersion < [8,6] then [] else
-  [ check "replace hole `_convertme` with localConvert"
-          "_convertme"   "n" "n"
-          "localConvert" "n" "n"
 
+#if MIN_GHC_API_VERSION(8,6,0)
   , check "replace hole `_c` with parameterInt"
           "_a" "_b" "_c"
           "_a" "_b"  "parameterInt"
+#endif
   ]
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
Add code actions which replace typed holes, using GHC's "Relevant bindings include" hints.
