### PR TITLE
Cleanup GHC API version checks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,3 +101,47 @@ jobs:
                --data "{\"text\":\"<!here> *FAILED* $(Agent.JobName): <https://dev.azure.com/digitalasset/ghcide/_build/results?buildId=$(Build.BuildId)|$MESSAGE>\n\"}" \
                $(Slack.URL)
         condition: and(failed(), eq(variables['Build.SourceBranchName'], 'master'))
+  - job: ghcide_stack_ghc_lib_88
+    timeoutInMinutes: 60
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+      - checkout: self
+      - task: CacheBeta@0
+        inputs:
+          key: stack-cache-v1 | $(Agent.OS) | $(Build.SourcesDirectory)/stack-ghc-lib.yaml | $(Build.SourcesDirectory)/ghcide.cabal
+          path: .azure-cache
+          cacheHitVar: CACHE_RESTORED
+        displayName: "Cache stack artifacts"
+      - bash: |
+          mkdir -p ~/.stack
+          tar xzf .azure-cache/stack-root.tar.gz -C $HOME
+        displayName: "Unpack cache"
+        condition: eq(variables.CACHE_RESTORED, 'true')
+      - bash: |
+          ./fmt.sh
+        displayName: "HLint via ./fmt.sh"
+      - bash: |
+          sudo apt-get install -y g++ gcc libc6-dev libffi-dev libgmp-dev make zlib1g-dev
+          curl -sSL https://get.haskellstack.org/ | sh
+        displayName: 'Install Stack'
+      - bash: stack setup --stack-yaml=stack-ghc-lib.yaml
+        displayName: 'stack setup --stack-yaml=stack-ghc-lib.yaml'
+      - bash: stack build --only-dependencies --stack-yaml=stack-ghc-lib.yaml
+        displayName: 'stack build --only-dependencies --stack-yaml=stack-ghc-lib.yaml'
+      - bash: stack test --stack-yaml=stack-ghc-lib.yaml || stack test --stack-yaml=stack-ghc-lib.yaml || stack test --stack-yaml=stack-ghc-lib.yaml
+        # ghcide stack tests are flaky, see https://github.com/digital-asset/daml/issues/2606.
+        displayName: 'stack test --stack-yaml=stack-ghc-lib.yaml'
+      - bash: |
+          mkdir -p .azure-cache
+          tar czf .azure-cache/stack-root.tar.gz -C $HOME .stack
+        displayName: "Pack cache"
+      - bash: |
+          set -euo pipefail
+          MESSAGE=$(git log --pretty=format:%s -n1)
+          curl -XPOST \
+               -i \
+               -H 'Content-type: application/json' \
+               --data "{\"text\":\"<!here> *FAILED* $(Agent.JobName): <https://dev.azure.com/digitalasset/ghcide/_build/results?buildId=$(Build.BuildId)|$MESSAGE>\n\"}" \
+               $(Slack.URL)
+        condition: and(failed(), eq(variables['Build.SourceBranchName'], 'master'))

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -14,10 +14,16 @@ description:
 homepage:           https://github.com/digital-asset/ghcide#readme
 bug-reports:        https://github.com/digital-asset/ghcide/issues
 tested-with:        GHC==8.6.5
+extra-source-files: include/ghc-api-version.h README.md
 
 source-repository head
     type:     git
     location: https://github.com/digital-asset/ghcide.git
+
+flag ghc-lib
+  description: build against ghc-lib instead of the ghc package
+  default: False
+  manual: True
 
 library
     default-language:   Haskell2010
@@ -33,9 +39,6 @@ library
         directory,
         extra,
         filepath,
-        ghc-boot-th,
-        ghc-boot,
-        ghc >= 8.4,
         hashable,
         haskell-lsp-types,
         haskell-lsp >= 0.15,
@@ -55,13 +58,22 @@ library
         transformers,
         unordered-containers,
         utf8-string
+    if flag(ghc-lib)
+      build-depends:
+        ghc-lib >= 8.8,
+        ghc-lib-parser >= 8.8
+      cpp-options: -DGHC_LIB
+    else
+      build-depends:
+        ghc-boot-th,
+        ghc-boot,
+        ghc >= 8.4
     if !os(windows)
       build-depends:
         unix
       c-sources:
         cbits/getmodtime.c
 
-    cpp-options: -DGHC_STABLE
     default-extensions:
         BangPatterns
         DeriveFunctor
@@ -79,6 +91,8 @@ library
 
     hs-source-dirs:
         src
+    include-dirs:
+        include
     exposed-modules:
         Development.IDE.Core.FileStore
         Development.IDE.Core.OfInterest
@@ -116,6 +130,8 @@ library
         Development.IDE.Spans.Type
 
 executable ghcide
+    if flag(ghc-lib)
+      buildable: False
     default-language:   Haskell2010
     hs-source-dirs:     exe
     ghc-options: -threaded
@@ -144,6 +160,8 @@ executable ghcide
         ViewPatterns
 
 test-suite ghcide-tests
+    if flag(ghc-lib)
+      buildable: False
     type: exitcode-stdio-1.0
     default-language: Haskell2010
     build-tool-depends:

--- a/include/ghc-api-version.h
+++ b/include/ghc-api-version.h
@@ -1,0 +1,10 @@
+#ifndef GHC_API_VERSION_H
+#define GHC_API_VERSION_H
+
+#ifdef GHC_LIB
+#define MIN_GHC_API_VERSION(x,y,z) MIN_VERSION_ghc_lib(x,y,z)
+#else
+#define MIN_GHC_API_VERSION(x,y,z) MIN_VERSION_ghc(x,y,z)
+#endif
+
+#endif

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -3,6 +3,7 @@
 
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE CPP #-}
+#include "ghc-api-version.h"
 
 -- | Based on https://ghc.haskell.org/trac/ghc/wiki/Commentary/Compiler/API.
 --   Given a list of paths to find libraries, and a file to compile, produce a list of 'CoreModule' values.
@@ -225,7 +226,7 @@ getModSummaryFromBuffer fp contents dflags parsed = do
           { ml_hs_file  = Just fp
           , ml_hi_file  = derivedFile "hi"
           , ml_obj_file = derivedFile "o"
-#ifndef GHC_STABLE
+#if MIN_GHC_API_VERSION(8,8,0)
           , ml_hie_file = derivedFile "hie"
 #endif
           -- This does not consider the dflags configuration
@@ -250,7 +251,7 @@ getModSummaryFromBuffer fp contents dflags parsed = do
     , ms_hsc_src      = sourceType
     , ms_obj_date     = Nothing
     , ms_iface_date   = Nothing
-#ifndef GHC_STABLE
+#if MIN_GHC_API_VERSION(8,8,0)
     , ms_hie_date     = Nothing
 #endif
     , ms_srcimps      = [imp | (True, imp) <- imports]

--- a/src/Development/IDE/GHC/CPP.hs
+++ b/src/Development/IDE/GHC/CPP.hs
@@ -9,6 +9,7 @@
 
 {-# LANGUAGE CPP, NamedFieldPuns, NondecreasingIndentation, BangPatterns, MultiWayIf #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+#include "ghc-api-version.h"
 
 -----------------------------------------------------------------------------
 --
@@ -27,7 +28,7 @@ import Module
 import DynFlags
 import Panic
 import FileCleanup
-#ifndef GHC_STABLE
+#if MIN_GHC_API_VERSION(8,8,0)
 import LlvmCodeGen (LlvmVersion (..))
 #endif
 
@@ -136,11 +137,11 @@ getBackendDefs :: DynFlags -> IO [String]
 getBackendDefs dflags | hscTarget dflags == HscLlvm = do
     llvmVer <- figureLlvmVersion dflags
     return $ case llvmVer of
-#ifdef GHC_STABLE
-               Just n -> [ "-D__GLASGOW_HASKELL_LLVM__=" ++ format n ]
-#else
+#if MIN_GHC_API_VERSION(8,8,0)
                Just (LlvmVersion n) -> [ "-D__GLASGOW_HASKELL_LLVM__=" ++ format (n,0) ]
                Just (LlvmVersionOld m n) -> [ "-D__GLASGOW_HASKELL_LLVM__=" ++ format (m,n) ]
+#else
+               Just n -> [ "-D__GLASGOW_HASKELL_LLVM__=" ++ format n ]
 #endif
                _      -> []
   where

--- a/src/Development/IDE/GHC/Compat.hs
+++ b/src/Development/IDE/GHC/Compat.hs
@@ -2,6 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE CPP #-}
+#include "ghc-api-version.h"
 
 -- | Attempt at hiding the GHC version differences we can.
 module Development.IDE.GHC.Compat(
@@ -21,7 +22,11 @@ import StringBuffer
 import DynFlags
 import GHC.LanguageExtensions.Type
 
-#ifndef GHC_STABLE
+#if MIN_GHC_API_VERSION(8,8,0)
+import Data.List.Extra (enumerate)
+#endif
+
+#if MIN_GHC_API_VERSION(8,8,0)
 import HieAst
 import HieBin
 import HieTypes
@@ -53,7 +58,7 @@ data HieFile = HieFile {hie_module :: (), hie_exports :: [AvailInfo]}
 data HieFileResult = HieFileResult { hie_file_result :: HieFile }
 #endif
 
-#if __GLASGOW_HASKELL__ < 806
+#if !MIN_GHC_API_VERSION(8,6,0)
 includePathsGlobal, includePathsQuote :: [String] -> [String]
 includePathsGlobal = id
 includePathsQuote = const []
@@ -61,7 +66,7 @@ includePathsQuote = const []
 
 
 addIncludePathsQuote :: FilePath -> DynFlags -> DynFlags
-#if __GLASGOW_HASKELL__ >= 806
+#if MIN_GHC_API_VERSION(8,6,0)
 addIncludePathsQuote path x = x{includePaths = f $ includePaths x}
     where f i = i{includePathsQuote = path : includePathsQuote i}
 #else
@@ -69,9 +74,9 @@ addIncludePathsQuote path x = x{includePaths = path : includePaths x}
 #endif
 
 ghcEnumerateExtensions :: [Extension]
-#if __GLASGOW_HASKELL__ >= 808
+#if MIN_GHC_API_VERSION(8,8,0)
 ghcEnumerateExtensions = enumerate
-#elif __GLASGOW_HASKELL__ >= 806
+#elif MIN_GHC_API_VERSION(8,6,0)
 ghcEnumerateExtensions = [Cpp .. StarIsType]
 #else
 ghcEnumerateExtensions = [Cpp .. EmptyDataDeriving]

--- a/src/Development/IDE/GHC/Util.hs
+++ b/src/Development/IDE/GHC/Util.hs
@@ -3,6 +3,7 @@
 
 {-# OPTIONS_GHC -Wno-missing-fields #-} -- to enable prettyPrint
 {-# LANGUAGE CPP #-}
+#include "ghc-api-version.h"
 
 -- | GHC utility functions. Importantly, code using our GHC should never:
 --
@@ -22,7 +23,7 @@ module Development.IDE.GHC.Util(
 
 import Config
 import Data.List.Extra
-#if __GLASGOW_HASKELL__ >= 806
+#if MIN_GHC_API_VERSION(8,6,0)
 import Fingerprint
 #endif
 import GHC
@@ -88,7 +89,7 @@ fakeDynFlags = defaultDynFlags settings mempty
                    , sPlatformConstants = platformConstants
                    , sProgramName = "ghc"
                    , sProjectVersion = cProjectVersion
-#if __GLASGOW_HASKELL__ >= 806
+#if MIN_GHC_API_VERSION(8,6,0)
                     , sOpt_P_fingerprint = fingerprint0
 #endif
                     }

--- a/src/Development/IDE/Import/FindImports.hs
+++ b/src/Development/IDE/Import/FindImports.hs
@@ -2,6 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE CPP #-}
+#include "ghc-api-version.h"
 
 module Development.IDE.Import.FindImports
   ( locateModule
@@ -108,7 +109,7 @@ notFoundErr dfs modName reason =
              { fr_pkgs_hidden = map (moduleUnitId . fst) pkg_hiddens
              , fr_mods_hidden = map (moduleUnitId . fst) mod_hiddens
              }
-#if __GLASGOW_HASKELL__ >= 806
+#if MIN_GHC_API_VERSION(8,6,0)
         LookupUnusable unusable ->
           let unusables' = map get_unusable unusable
               get_unusable (m, ModUnusable r) = (moduleUnitId m, r)
@@ -125,7 +126,7 @@ notFound = NotFound
   , fr_pkg = Nothing
   , fr_pkgs_hidden = []
   , fr_mods_hidden = []
-#if __GLASGOW_HASKELL__ >= 806
+#if MIN_GHC_API_VERSION(8,6,0)
   , fr_unusables = []
 #endif
   , fr_suggestions = []

--- a/src/Development/IDE/Spans/Calculate.hs
+++ b/src/Development/IDE/Spans/Calculate.hs
@@ -5,6 +5,7 @@
 
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
+#include "ghc-api-version.h"
 
 -- | Get information on modules, identifiers, etc.
 
@@ -34,7 +35,7 @@ import Development.IDE.GHC.Util
 
 -- A lot of things gained an extra X argument in GHC 8.6, which we mostly ignore
 -- this U ignores that arg in 8.6, but is hidden in 8.4
-#if __GLASGOW_HASKELL__ >= 806
+#if MIN_GHC_API_VERSION(8,6,0)
 #define U _
 #else
 #define U

--- a/stack-ghc-lib.yaml
+++ b/stack-ghc-lib.yaml
@@ -1,7 +1,6 @@
 resolver: nightly-2019-09-16
 packages:
 - .
-
 extra-deps:
 - git: https://github.com/alanz/haskell-lsp.git
   commit: bfbd8630504ebc57b70948689c37b85cfbe589da
@@ -12,5 +11,13 @@ extra-deps:
   commit: d126623dc6895d325e3d204d74e2a22d4f515587
 - git: https://github.com/mpickering/hie-bios.git
   commit: 89e4ba24f87aac9909d9814b0e8c51b679a0ccd4
+- ghc-lib-parser-8.8.1
+- ghc-lib-8.8.1
 nix:
   packages: [zlib]
+flags:
+  ghcide:
+    ghc-lib: True
+ghc-options:
+  ghc-lib-parser: -O0
+  ghc-lib: -O0


### PR DESCRIPTION
Previously we had a mix of GHC_STABLE and checks on
`__GLASGOW_HASKELL__`. This PR changes this to always check on
MIN_GHC_API_VERSION. Depending on whether you use ghc-lib or not (now
controlled by a cabal flag), this macro expands to MIN_VERSION_ghc or
MIN_VERSION_ghc_lib.