### PR TITLE
Add -Iinclude where it's needed

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -17,6 +17,7 @@
 :set -package=ghc
 :set -hide-package=ghc-lib-parser
 :set -DGHC_STABLE
+:set -Iinclude
 :set -isrc
 :set -iexe
 

--- a/hie.yaml
+++ b/hie.yaml
@@ -23,6 +23,7 @@ cradle:
       - -ignore-package=ghc-lib-parser
       - -ignore-package=ghc-lib
       - -DGHC_STABLE
+      - -Iinclude
       - -isrc
       - -iexe
       - -itest/cabal


### PR DESCRIPTION
Before `stack run ghcide` reported that about half the ghcide files couldn't load. Now it reports only 2 can't load, which is what it's always been. Also fixes the `ghcid` experience.

I suspect we should probably have a test that `ghcide` works on `ghcide` itself, but it doesn't completely work because its multiple components etc so I've no real idea what to do.