### PR TITLE
Use a consistent include dir for cwd

### DIFF
--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -158,7 +158,7 @@ upgradeWarningToError (nfp, fd) = (nfp, fd{_severity = Just DsError})
 
 addRelativeImport :: ParsedModule -> DynFlags -> DynFlags
 addRelativeImport modu dflags = dflags
-    {importPaths = nubOrd $ maybeToList (moduleImportPaths modu) ++ importPaths dflags}
+    {importPaths = nubOrd $ maybeToList (moduleImportPath modu) ++ importPaths dflags}
 
 mkTcModuleResult
     :: GhcMonad m


### PR DESCRIPTION
This only matters for the DAML codebase (so I’ll add a test on that
side) where we use relative paths:

Previously, we would produce the include dir "." for moduleImportPath
"./A.daml"
and "" for moduleImportPath "./A/B.daml". This resulted in us ending
up with ./A.daml and A.daml in the Shake graph which resulted in
issues like https://github.com/digital-asset/daml/issues/2929.

We should move this logic completely over to the DAML repo at some
point but I’ll leave that for a separate PR.