### PR TITLE
Add Paths_ghcide, fixes a warning

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -154,6 +154,7 @@ executable ghcide
         text
     other-modules:
         Arguments
+        Paths_ghcide
 
     default-extensions:
         RecordWildCards


### PR DESCRIPTION
Stack warns about misplaced home modules