### PR TITLE
No warnings

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,11 +39,11 @@ jobs:
         displayName: 'Install Stack'
       - bash: stack setup
         displayName: 'stack setup'
-      - bash: stack build --only-dependencies --ghc-options=-Werror
+      - bash: stack build --only-dependencies
         displayName: 'stack build --only-dependencies'
-      - bash: stack test || stack test || stack test
+      - bash: stack test --ghc-options=-Werror || stack test --ghc-options=-Werror || stack test --ghc-options=-Werror
         # ghcide stack tests are flaky, see https://github.com/digital-asset/daml/issues/2606.
-        displayName: 'stack test'
+        displayName: 'stack test --ghc-options=-Werror'
       - bash: |
           mkdir -p .azure-cache
           tar czf .azure-cache/stack-root.tar.gz -C $HOME .stack
@@ -83,11 +83,11 @@ jobs:
         displayName: 'Install Stack'
       - bash: stack setup --stack-yaml=stack84.yaml
         displayName: 'stack setup --stack-yaml=stack84.yaml'
-      - bash: stack build --only-dependencies --stack-yaml=stack84.yaml --ghc-options=-Werror
+      - bash: stack build --only-dependencies --stack-yaml=stack84.yaml
         displayName: 'stack build --only-dependencies --stack-yaml=stack84.yaml'
-      - bash: stack test --stack-yaml=stack84.yaml || stack test --stack-yaml=stack84.yaml || stack test --stack-yaml=stack84.yaml
+      - bash: stack test --stack-yaml=stack84.yaml --ghc-options=-Werror || stack test --stack-yaml=stack84.yaml  --ghc-options=-Werror || stack test --stack-yaml=stack84.yaml  --ghc-options=-Werror
         # ghcide stack tests are flaky, see https://github.com/digital-asset/daml/issues/2606.
-        displayName: 'stack test --stack-yaml=stack84.yaml'
+        displayName: 'stack test --stack-yaml=stack84.yaml --ghc-options=-Werror'
       - bash: |
           mkdir -p .azure-cache
           tar czf .azure-cache/stack-root.tar.gz -C $HOME .stack
@@ -127,11 +127,11 @@ jobs:
         displayName: 'Install Stack'
       - bash: stack setup --stack-yaml=stack-ghc-lib.yaml
         displayName: 'stack setup --stack-yaml=stack-ghc-lib.yaml'
-      - bash: stack build --only-dependencies --stack-yaml=stack-ghc-lib.yaml --ghc-options=-Werror
+      - bash: stack build --only-dependencies --stack-yaml=stack-ghc-lib.yaml
         displayName: 'stack build --only-dependencies --stack-yaml=stack-ghc-lib.yaml'
-      - bash: stack test --stack-yaml=stack-ghc-lib.yaml || stack test --stack-yaml=stack-ghc-lib.yaml || stack test --stack-yaml=stack-ghc-lib.yaml
+      - bash: stack test --stack-yaml=stack-ghc-lib.yaml --ghc-options=-Werror || stack test --stack-yaml=stack-ghc-lib.yaml --ghc-options=-Werror || stack test --stack-yaml=stack-ghc-lib.yaml --ghc-options=-Werror
         # ghcide stack tests are flaky, see https://github.com/digital-asset/daml/issues/2606.
-        displayName: 'stack test --stack-yaml=stack-ghc-lib.yaml'
+        displayName: 'stack test --stack-yaml=stack-ghc-lib.yaml --ghc-options=-Werror'
       - bash: |
           mkdir -p .azure-cache
           tar czf .azure-cache/stack-root.tar.gz -C $HOME .stack

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -60,9 +60,6 @@ import qualified Development.IDE.Spans.AtPoint as AtPoint
 import Development.IDE.Core.Service
 import Development.IDE.Core.Shake
 import Development.Shake.Classes
-import System.Directory
-import System.FilePath
-import MkIface
 
 -- | This is useful for rules to convert rules that can only produce errors or
 -- a result into the more general IdeResult type that supports producing


### PR DESCRIPTION
Warnings are bad. Delete the 3 that got introduced, then fix the Azure pipelines, which was previously checking that the dependencies had no warnings (don't care), but not that the build had no errors (care a lot).