### PR TITLE
Fix deferred messages

### DIFF
--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -154,7 +154,10 @@ unDefer (Reason Opt_WarnDeferredOutOfScopeVariables, fd) = upgradeWarningToError
 unDefer ( _                                        , fd) = fd
 
 upgradeWarningToError :: FileDiagnostic -> FileDiagnostic
-upgradeWarningToError (nfp, fd) = (nfp, fd{_severity = Just DsError})
+upgradeWarningToError (nfp, fd) =
+  (nfp, fd{_severity = Just DsError, _message = warn2err $ _message fd}) where
+  warn2err :: T.Text -> T.Text
+  warn2err = T.intercalate ": error:" . T.splitOn ": warning:"
 
 addRelativeImport :: ParsedModule -> DynFlags -> DynFlags
 addRelativeImport modu dflags = dflags

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -117,9 +117,10 @@ diagnosticTests = testGroup "diagnostics"
           _ <- openDoc' "B.hs" "haskell"   sourceB
           expectDiagnostics $ expectedDs message
     in
-    [ deferralTest "type error"       "True"    "Couldn't match expected type"
-    , deferralTest "typed hole"       "_"       "Found hole"
-    , deferralTest "out of scope var" "unbound" "Variable not in scope"
+    [ deferralTest "type error"          "True"    "Couldn't match expected type"
+    , deferralTest "typed hole"          "_"       "Found hole"
+    , deferralTest "out of scope var"    "unbound" "Variable not in scope"
+    , deferralTest "message shows error" "True"    "A.hs:3:5: error:"
     ]
 
   , testSession "remove required module" $ do


### PR DESCRIPTION
The text of the error messages of deferred type errors / typed holes / out of scope variables, refer to them as warnings, even after they have been upgraded back to errors. This PR fixes these messages.
