### PR TITLE
Add an upper bound to hie-bios

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -147,7 +147,7 @@ executable ghcide
         ghc-paths,
         ghc,
         haskell-lsp,
-        hie-bios >= 0.2,
+        hie-bios >= 0.2 && < 0.3,
         ghcide,
         optparse-applicative,
         shake,


### PR DESCRIPTION
We are coupled very tightly to the hie-bios API, and I'm sure 0.3 will break us, so put in a preemptive upper bound. I suggest going forward we always constrain ourselves to a specific hie-bios given the close coupling.

CC @mpickering 