### PR TITLE
Update extension metadata

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,13 +1,14 @@
 {
 	"name": "ghcide",
 	"displayName": "ghcide",
-	"publisher": "digitalasset",
+	"publisher": "DigitalAssetHoldingsLLC",
 	"repository": {
 		"type" : "git",
 		"url" : "https://github.com/digitalasset/daml.git"
 	},
 	"description": "A simple extension to test out haskell ide core",
 	"version": "0.0.1",
+    "license": "Apache-2.0",
 	"engines": {
 		"vscode": "^1.35.0"
 	},


### PR DESCRIPTION
That’s the publisher we use for uploading the DAML extension and it
makes little sense to have two publishers.