### PR TITLE
Add tests for find-definition and hover

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -187,6 +187,7 @@ test-suite ghcide-tests
         parser-combinators,
         tasty,
         tasty-hunit,
+        tasty-expected-failure,
         text
     hs-source-dirs: test/cabal test/exe test/src
     include-dirs: include

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -648,7 +648,7 @@ findDefinitionTests = let
   aaa    = mkRange   6  0    6  3
   vv     = mkRange  15  4   15  6
   op     = mkRange  16  2   16  4
-  opp    = mkRange  17 13   17 15
+  opp    = mkRange  17 13   17 17
   apmp   = mkRange  17 10   17 11
   bp     = mkRange  18  6   18  7
   -- search locations
@@ -661,7 +661,7 @@ findDefinitionTests = let
   tcL5   = Position  5 11
   vvL15  = Position 15 12
   opL15  = Position 15 15
-  opL17  = Position 17 21
+  opL17  = Position 17 22
   aL17   = Position 17 20
   b'L18  = Position 18 13
 
@@ -681,7 +681,7 @@ findDefinitionTests = let
     , tst d vvL15  vv     "plain parameter"
     , tst d aL17   apmp   "pattern match name"
     , tst d opL15  op     "top-level operator"            -- 123
-    , tst d opL17  opp    "parameter operator"           `xfail` "known broken"
+    , tst d opL17  opp    "parameter operator"
     , tst d b'L18  bp     "name in backticks"
     ]
   , testGroup "hover"
@@ -695,7 +695,7 @@ findDefinitionTests = let
     , tst h vvL15  vv     "plain parameter"
     , tst h aL17   apmp   "pattern match name"
     , tst h opL15  op     "top-level operator"           -- 123
-    , tst d opL17  opp    "parameter operator"           `xfail` "known broken"
+    , tst d opL17  opp    "parameter operator"
     , tst h b'L18  bp     "name in backticks"
     ]
   ]

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -610,7 +610,7 @@ findDefinitionTests = let
       Just Hover{_contents = (HoverContents MarkupContent{_value = v})} ->
         liftIO $ adjust expected @=? Position l c where
           found = T.splitOn ":" $ head $ T.splitOn "**" $ last $ T.splitOn "Testing.hs:" v
-          [l,c] =  map (read . T.unpack) $ found
+          [l,c] =  map (read . T.unpack) found
           -- looks like hovers use 1-based numbering while definitions use 0-based
           adjust Range{_start = Position{_line = l, _character = c}} =
             Position{_line = l + 1, _character = c + 1}
@@ -671,30 +671,30 @@ findDefinitionTests = let
   testGroup "get"
   [ testGroup "definition"
     [ tst d fffL3  fff    "field in record definition"
-    ,(tst d fffL7  fff    "field in record construction") `xfail` "known broken"
+    , tst d fffL7  fff    "field in record construction" `xfail` "known broken"
     , tst d fffL13 fff    "field name used as accessor"   -- 120 in Calculate.hs
     , tst d aaaL13 aaa    "top-level name"                -- 120
-    ,(tst d dcL6   tcDC   "record data constructor")      `xfail` "known broken"
+    , tst d dcL6   tcDC   "record data constructor"      `xfail` "known broken"
     , tst d dcL11  tcDC   "plain  data constructor"       -- 121
     , tst d tcL5   tcData "type constructor"              -- 147
     , tst d vvL15  vv     "plain parameter"
     , tst d aL17   apmp   "pattern match name"
     , tst d opL15  op     "top-level operator"
-    ,(tst d opL17  opp    "parameter operator")           `xfail` "known broken"
+    , tst d opL17  opp    "parameter operator"           `xfail` "known broken"
     , tst d b'L18  bp     "name in backticks"
     ]
   , testGroup "hover"
     [ tst h fffL3  fff    "field in record definition"
-    ,(tst h fffL7  fff    "field in record construction") `xfail` "known broken"
+    , tst h fffL7  fff    "field in record construction" `xfail` "known broken"
     , tst h fffL13 fff    "field name used as accessor"   -- 120
     , tst h aaaL13 aaa    "top-level name"                -- 120
-    ,(tst h dcL6   tcDC   "record data constructor")      `xfail` "known broken"
+    , tst h dcL6   tcDC   "record data constructor"      `xfail` "known broken"
     , tst h dcL11  tcDC   "plain  data constructor"       -- 121
-    ,(tst h tcL5   tcData "type constructor")             `xfail` "known broken"
+    , tst h tcL5   tcData "type constructor"             `xfail` "known broken"
     , tst h vvL15  vv     "plain parameter"
     , tst h aL17   apmp   "pattern match name"
     , tst h opL15  op     "top-level operator"
-    ,(tst d opL17  opp    "parameter operator")           `xfail` "known broken"
+    , tst d opL17  opp    "parameter operator"           `xfail` "known broken"
     , tst h b'L18  bp     "name in backticks"
     ]
   ]

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -634,17 +634,23 @@ findDefinitionTests = let
     , "ccc = (fff bbb, ggg aaa)"                 -- 13
     , "ddd :: Num a => a -> a -> a"              -- 14
     , "ddd vv ww = vv +! ww"                     -- 15
-    , "a +! b = a - b"
+    , "a +! b = a - b"                           -- 16
+    , "hhh (Just a) (><) = a >< a"               -- 17
+    , "iii a b = a `b` a"                        -- 18
     -- 0123456789 123456789 123456789 123456789
     ]
 
+  -- definition locations
   tcData = mkRange   2  0    4 16
   tcDC   = mkRange   2 23    4 16
   fff    = mkRange   3  4    3  7
   aaa    = mkRange   6  0    6  3
   vv     = mkRange  15  4   15  6
   op     = mkRange  16  2   16  4
-
+  opp    = mkRange  17 13   17 15
+  apmp   = mkRange  17 10   17 11
+  bp     = mkRange  18  6   18  7
+  -- search locations
   fffL3  = _start fff
   fffL7  = Position  7  4
   fffL13 = Position 13  7
@@ -654,6 +660,9 @@ findDefinitionTests = let
   tcL5   = Position  5 11
   vvL15  = Position 15 12
   opL15  = Position 15 15
+  opL17  = Position 17 21
+  aL17   = Position 17 20
+  b'L18  = Position 18 13
 
   --t = (getTypeDefinitions, checkTDefs) -- getTypeDefinitions always times out
   d = (getDefinitions, checkDefs)
@@ -669,7 +678,10 @@ findDefinitionTests = let
     , tst d dcL11  tcDC   "plain  data constructor"       -- 121
     , tst d tcL5   tcData "type constructor"              -- 147
     , tst d vvL15  vv     "plain parameter"
+    , tst d aL17   apmp   "pattern match name"
     , tst d opL15  op     "top-level operator"
+    ,(tst d opL17  opp    "parameter operator")           `xfail` "known broken"
+    , tst d b'L18  bp     "name in backticks"
     ]
   , testGroup "hover"
     [ tst h fffL3  fff    "field in record definition"
@@ -680,7 +692,10 @@ findDefinitionTests = let
     , tst h dcL11  tcDC   "plain  data constructor"       -- 121
     ,(tst h tcL5   tcData "type constructor")             `xfail` "known broken"
     , tst h vvL15  vv     "plain parameter"
+    , tst h aL17   apmp   "pattern match name"
     , tst h opL15  op     "top-level operator"
+    ,(tst d opL17  opp    "parameter operator")           `xfail` "known broken"
+    , tst h b'L18  bp     "name in backticks"
     ]
   ]
 

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -614,6 +614,7 @@ findDefinitionTests = let
           -- looks like hovers use 1-based numbering while definitions use 0-based
           adjust Range{_start = Position{_line = l, _character = c}} =
             Position{_line = l + 1, _character = c + 1}
+      _ -> error "test not expecting this kind of hover info"
 
   source = T.unlines
     -- 0123456789 123456789 123456789 123456789

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -599,14 +599,14 @@ findDefinitionTests = let
     let ndef = length defs
     if ndef /= 1
       then let dfound n = "definitions found: " <> show n in
-           liftIO $ dfound 1 @=? dfound (length defs)
+           liftIO $ dfound (1 :: Int) @=? dfound (length defs)
       else do
            let [Location{_range = foundRange}] = defs
            liftIO $ expected @=? foundRange
 
   checkHover hover expected = do
     case hover of
-      Nothing -> liftIO $ "hover found" @=? "no hover found"
+      Nothing -> liftIO $ "hover found" @=? ("no hover found" :: T.Text)
       Just Hover{_contents = (HoverContents MarkupContent{_value = v})} ->
         liftIO $ adjust expected @=? Position l c where
           found = T.splitOn ":" $ head $ T.splitOn "**" $ last $ T.splitOn "Testing.hs:" v

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -679,7 +679,7 @@ findDefinitionTests = let
     , tst d tcL5   tcData "type constructor"              -- 147
     , tst d vvL15  vv     "plain parameter"
     , tst d aL17   apmp   "pattern match name"
-    , tst d opL15  op     "top-level operator"
+    , tst d opL15  op     "top-level operator"            -- 123
     , tst d opL17  opp    "parameter operator"           `xfail` "known broken"
     , tst d b'L18  bp     "name in backticks"
     ]
@@ -693,7 +693,7 @@ findDefinitionTests = let
     , tst h tcL5   tcData "type constructor"             `xfail` "known broken"
     , tst h vvL15  vv     "plain parameter"
     , tst h aL17   apmp   "pattern match name"
-    , tst h opL15  op     "top-level operator"
+    , tst h opL15  op     "top-level operator"           -- 123
     , tst d opL17  opp    "parameter operator"           `xfail` "known broken"
     , tst h b'L18  bp     "name in backticks"
     ]


### PR DESCRIPTION
These tests document what works or doesn't work in terms of hover and find definition. Tests corresponding to features which do not work are marked as expected to fail, allowing the test suite as a whole to pass.

The current state of play is:

| | find definition | hover |
|-------------|-----------|---------|
| field in record definition | :heavy_check_mark:  | :heavy_check_mark: |
| field in record construction | :exclamation:  | :exclamation: |
| field name as accessor | :heavy_check_mark: | :heavy_check_mark: |
| top level name | :heavy_check_mark: | :heavy_check_mark: |
| record data constructor | :exclamation: | :exclamation:  |
| plain data constructor | :heavy_check_mark: | :heavy_check_mark:  |
| type constructor | :heavy_check_mark: | :exclamation: |
| plain parameter | :heavy_check_mark: | :heavy_check_mark: |
| pattern match name | :heavy_check_mark: | :heavy_check_mark: |
| top level operator | :heavy_check_mark: | :heavy_check_mark: |
| parameter operator | :heavy_check_mark:  | :heavy_check_mark:  |
| name in backticks | :heavy_check_mark: | :heavy_check_mark: |

Curiously, hover over type constructors finds no information, while go-to-definition works. In all other cases tested here, either both hover and go-to-definition work, or neither of them does.

Plenty more test cases can be found, but this is a start. Hopefully the existence of these tests can help focus discussions such as those in #71 and #70, as well as assisting anybody working on fixing, improving or refactoring the relevant code.
