### PR TITLE
Bump GHC 8.8 stacksnapshot

### DIFF
--- a/stack88.yaml
+++ b/stack88.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2019-09-29
+resolver: nightly-2019-10-02
 packages:
 - .
 extra-deps:
@@ -8,7 +8,6 @@ extra-deps:
 - hslogger-1.3.0.0
 - lsp-test-0.7.0.0
 - network-bsd-2.8.1.0
-- aeson-pretty-0.8.7
 - conduit-parse-0.2.1.0
 allow-newer: true
 nix:


### PR DESCRIPTION
Still not at a point where all our deps are back in stackage but we’re
getting closer.