### PR TITLE
Avoid file path normalization in moduleImportPath

### DIFF
--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -159,9 +159,9 @@ upgradeWarningToError (nfp, fd) =
   warn2err :: T.Text -> T.Text
   warn2err = T.intercalate ": error:" . T.splitOn ": warning:"
 
-addRelativeImport :: ParsedModule -> DynFlags -> DynFlags
-addRelativeImport modu dflags = dflags
-    {importPaths = nubOrd $ maybeToList (moduleImportPath modu) ++ importPaths dflags}
+addRelativeImport :: NormalizedFilePath -> ParsedModule -> DynFlags -> DynFlags
+addRelativeImport fp modu dflags = dflags
+    {importPaths = nubOrd $ maybeToList (moduleImportPath fp modu) ++ importPaths dflags}
 
 mkTcModuleResult
     :: GhcMonad m

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -153,7 +153,7 @@ getLocatedImportsRule =
         let ms = pm_mod_summary pm
         let imports = [(False, imp) | imp <- ms_textual_imps ms] ++ [(True, imp) | imp <- ms_srcimps ms]
         env <- hscEnv <$> use_ GhcSession file
-        let dflags = addRelativeImport pm $ hsc_dflags env
+        let dflags = addRelativeImport file pm $ hsc_dflags env
         opt <- getIdeOptions
         (diags, imports') <- fmap unzip $ forM imports $ \(isSource, (mbPkgName, modName)) -> do
             diagOrImp <- locateModule dflags (optExtensions opt) getFileExists modName mbPkgName isSource


### PR DESCRIPTION
This fixes some issues where we used an uppercase drive letter in the
import path even though the LSP client uses lowercase drive letters