### PR TITLE
Issue visual warning for humans if --lsp option used

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -75,6 +75,7 @@ main = do
     if argLSP then do
         t <- offsetTime
         hPutStrLn stderr "Starting LSP server..."
+        hPutStrLn stderr "If you are seeing this in a terminal, you probably should have run ghcidie WITHOUT the --lsp option!"
         runLanguageServer def def $ \event vfs caps -> do
             t <- t
             hPutStrLn stderr $ "Started LSP server in " ++ showDuration t


### PR DESCRIPTION
Experience shows (e.g. #160) that people sometimes mistakenly start `ghcide` on
the command line with the `--lsp` option (which is intended to be used
only in server/client communication scenarios) and then wonder why
nothing is working..

So let's issue a warning message whenever `--lsp` is used.
