### PR TITLE
Move test sample code out to external file

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -173,6 +173,7 @@ test-suite ghcide-tests
         ghcide:ghcide
     build-depends:
         base,
+        bytestring,
         containers,
         directory,
         extra,
@@ -185,6 +186,7 @@ test-suite ghcide-tests
         -- which works for now.
         ghc,
         --------------------------------------------------------------
+        ghcide,
         haskell-lsp-types,
         lens,
         lsp-test >= 0.8,

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -15,6 +15,7 @@ homepage:           https://github.com/digital-asset/ghcide#readme
 bug-reports:        https://github.com/digital-asset/ghcide/issues
 tested-with:        GHC==8.6.5
 extra-source-files: include/ghc-api-version.h README.md CHANGELOG.md
+                    test/data/GotoHover.hs
 
 source-repository head
     type:     git

--- a/src/Development/IDE/GHC/Util.hs
+++ b/src/Development/IDE/GHC/Util.hs
@@ -18,7 +18,8 @@ module Development.IDE.GHC.Util(
     runGhcEnv,
     textToStringBuffer,
     moduleImportPath,
-    HscEnvEq, hscEnv, newHscEnvEq
+    HscEnvEq, hscEnv, newHscEnvEq,
+    readFileUtf8
     ) where
 
 import Config
@@ -35,7 +36,10 @@ import FileCleanup
 import Platform
 import Data.Unique
 import Development.Shake.Classes
-import qualified Data.Text as T
+import qualified Data.Text                as T
+import qualified Data.Text.Encoding       as T
+import qualified Data.Text.Encoding.Error as T
+import qualified Data.ByteString          as BS
 import StringBuffer
 import System.FilePath
 
@@ -139,3 +143,6 @@ instance Eq HscEnvEq where
 
 instance NFData HscEnvEq where
   rnf (HscEnvEq a b) = rnf (hashUnique a) `seq` b `seq` ()
+
+readFileUtf8 :: FilePath -> IO T.Text
+readFileUtf8 f = T.decodeUtf8With T.lenientDecode <$> BS.readFile f

--- a/test/data/GotoHover.hs
+++ b/test/data/GotoHover.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -Wmissing-signatures #-}
-module Testing where
+module Testing ( module Testing )where
 import Data.Text (Text, pack)
 data TypeConstructor = DataConstructor
   { fff :: Text

--- a/test/data/GotoHover.hs
+++ b/test/data/GotoHover.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -Wmissing-signatures #-}
+
 module Testing ( module Testing )where
 import Data.Text (Text, pack)
 data TypeConstructor = DataConstructor

--- a/test/data/GotoHover.hs
+++ b/test/data/GotoHover.hs
@@ -1,0 +1,21 @@
+{-# OPTIONS_GHC -Wmissing-signatures #-}
+module Testing where
+import Data.Text (Text, pack)
+data TypeConstructor = DataConstructor
+  { fff :: Text
+  , ggg :: Int }
+aaa :: TypeConstructor
+aaa = DataConstructor
+  { fff = ""
+  , ggg = 0
+  }
+bbb :: TypeConstructor
+bbb = DataConstructor "" 0
+ccc :: (Text, Int)
+ccc = (fff bbb, ggg aaa)
+ddd :: Num a => a -> a -> a
+ddd vv ww = vv +! ww
+a +! b = a - b
+hhh (Just a) (><) = a >< a
+iii a b = a `b` a
+jjj s = pack $ s <> s

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -12,7 +12,8 @@ import Control.Monad
 import Control.Monad.IO.Class (liftIO)
 import Data.Char (toLower)
 import Data.Foldable
-import qualified Data.Text as T
+import qualified Data.Text    as T
+import qualified Data.Text.IO as T
 import Development.IDE.Test
 import Development.IDE.Test.Runfiles
 import Language.Haskell.LSP.Test
@@ -694,7 +695,7 @@ findDefinitionAndHoverTests :: TestTree
 findDefinitionAndHoverTests = let
 
   tst (get, check) pos targetRange title = testSession title $ do
-    doc <- openDoc' sourceFilePath "haskell" source
+    doc <- openTestDataDoc sourceFilePath
     found <- get doc pos
     check found targetRange
 
@@ -751,8 +752,8 @@ findDefinitionAndHoverTests = let
     (T.unpack $ "failed to find: `" <> part <> "` in hover message:\n" <> whole)
     (part `T.isInfixOf` whole)
 
-  sourceFilePath = "Testing.hs" -- TODO: convert from sourceFileName
-  sourceFileName = "Testing.hs"
+  sourceFilePath = T.unpack sourceFileName
+  sourceFileName = "GotoHover.hs"
 
   mkFindTests tests = testGroup "get"
     [ testGroup "definition" $ mapMaybe fst tests
@@ -764,33 +765,6 @@ findDefinitionAndHoverTests = let
       def   = (getDefinitions, checkDefs)
       hover = (getHover      , checkHover)
       --type_ = (getTypeDefinitions, checkTDefs) -- getTypeDefinitions always times out
-
-  source = T.unlines
-    -- 0123456789 123456789 123456789 123456789
-    [ "{-# OPTIONS_GHC -Wmissing-signatures #-}" --  0
-    , "module Testing where"                     --  1
-    , "import Data.Text (Text, pack)"            --  2
-    , "data TypeConstructor = DataConstructor"   --  3
-    , "  { fff :: Text"                          --  4
-    , "  , ggg :: Int }"                         --  5
-    , "aaa :: TypeConstructor"                   --  6
-    , "aaa = DataConstructor"                    --  7
-    , "  { fff = \"\""                           --  8
-    , "  , ggg = 0"                              --  9
-    -- 0123456789 123456789 123456789 123456789
-    , "  }"                                      -- 10
-    , "bbb :: TypeConstructor"                   -- 11
-    , "bbb = DataConstructor \"\" 0"             -- 12
-    , "ccc :: (Text, Int)"                       -- 13
-    , "ccc = (fff bbb, ggg aaa)"                 -- 14
-    , "ddd :: Num a => a -> a -> a"              -- 15
-    , "ddd vv ww = vv +! ww"                     -- 16
-    , "a +! b = a - b"                           -- 17
-    , "hhh (Just a) (><) = a >< a"               -- 18
-    , "iii a b = a `b` a"                        -- 19
-    , "jjj s = pack $ s <> s"                    -- 20
-    -- 0123456789 123456789 123456789 123456789
-    ]
 
   -- search locations            expectations on results
   fffL4  = _start fffR     ;  fffR = mkRange 4  4    4  7 ; fff  = [ExpectRange fffR]
@@ -888,3 +862,8 @@ run s = withTempDir $ \dir -> do
       -- If you uncomment this you can see all messages
       -- which can be quite useful for debugging.
       -- { logMessages = True, logColor = False, logStdErr = True }
+
+openTestDataDoc :: FilePath -> Session TextDocumentIdentifier
+openTestDataDoc path = do
+  source <- liftIO $ T.readFile $ "test/data" </> path
+  openDoc' path "haskell" source

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -12,8 +12,8 @@ import Control.Monad
 import Control.Monad.IO.Class (liftIO)
 import Data.Char (toLower)
 import Data.Foldable
-import qualified Data.Text    as T
-import qualified Data.Text.IO as T
+import Development.IDE.GHC.Util
+import qualified Data.Text as T
 import Development.IDE.Test
 import Development.IDE.Test.Runfiles
 import Language.Haskell.LSP.Test
@@ -865,5 +865,5 @@ run s = withTempDir $ \dir -> do
 
 openTestDataDoc :: FilePath -> Session TextDocumentIdentifier
 openTestDataDoc path = do
-  source <- liftIO $ T.readFile $ "test/data" </> path
+  source <- liftIO $ readFileUtf8 $ "test/data" </> path
   openDoc' path "haskell" source


### PR DESCRIPTION
This has been written on top of #168 which has not been merged yet: only the last 2 commits belong to this PR.

The sample code used in the goto def / hover tests, is becoming to unwieldy to be kept in strings in the test sources. So it has been moved out into a separate file in a new directory `test/data`.