### PR TITLE
Use IdeResult in generateCore

### DIFF
--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -280,7 +280,7 @@ typeCheckRule =
         IdeOptions{ optDefer = defer} <- getIdeOptions
         liftIO $ typecheckModule defer packageState tms pm
 
-generateCore :: NormalizedFilePath -> Action ([FileDiagnostic], Maybe CoreModule)
+generateCore :: NormalizedFilePath -> Action (IdeResult CoreModule)
 generateCore file = do
     deps <- use_ GetDependencies file
     (tm:tms) <- uses_ TypeCheck (file:transitiveModuleDeps deps)


### PR DESCRIPTION
use the `IdeResult` type synonym in the new `generateCore` function's return
type instead of effectively inlining it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/ghcide/180)
<!-- Reviewable:end -->
