### PR TITLE
Adapt code to use hie-bios's new CradleLoadResult

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -154,7 +154,12 @@ showEvent lock e = withLock lock $ print e
 
 cradleToSession :: Cradle -> IO HscEnvEq
 cradleToSession cradle = do
-    opts <- either throwIO return =<< getCompilerOptions "" cradle
+    result <- getCompilerOptions "" cradle
+    opts <- case result of
+        CradleSuccess x -> return x
+        CradleFail e -> throwIO e
+        CradleNone -> error "Not only did it not work, but there's no error either"
+
     libdir <- getLibdir
     env <- runGhc (Just libdir) $ do
         _targets <- initSession opts

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -158,7 +158,7 @@ cradleToSession cradle = do
     opts <- case result of
         CradleSuccess x -> return x
         CradleFail e -> throwIO e
-        CradleNone -> error "Not only did it not work, but there's no error either"
+        CradleNone -> fail "Skipping directory due to 'none' cradle"
 
     libdir <- getLibdir
     env <- runGhc (Just libdir) $ do

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -150,7 +150,7 @@ executable ghcide
         ghc-paths,
         ghc,
         haskell-lsp,
-        hie-bios >= 0.2 && < 0.3,
+        hie-bios >= 0.3 && < 0.4,
         ghcide,
         optparse-applicative,
         shake,


### PR DESCRIPTION
Unclear why **hie-bios** changed `getCompilerOptions` from its Either return type, but they did. This patch adapts the code in Main to handle this new type.

Bumps dependency on **hie-bios** to >= 0.3.0