### PR TITLE
Remove organize imports from the supported features

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ There are more details about our approach [in this blog post](https://4ta.uk/p/s
 | Go to definition in local package | definition  |
 | Display type and source module of values | hover |
 | Remove redundant imports, replace suggested typos for values and module imports, fill type holes, insert missing type signatures, add suggested ghc extensions  | codeAction (quickfix) |
-| Organize imports | codeAction (source.organizeImports) |
 
 ## Using it
 


### PR DESCRIPTION
We never supported this and still don’t so for now let’s remove it.