### PR TITLE
Support TemplateHaskell

### DIFF
--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -24,7 +24,7 @@ import           GHC.Generics                             (Generic)
 
 import           GHC
 import Module (InstalledUnitId)
-import HscTypes (HomeModInfo)
+import HscTypes (HomeModInfo, CompiledByteCode, SptEntry)
 import Development.IDE.GHC.Compat
 
 import           Development.IDE.Spans.Type
@@ -65,7 +65,16 @@ type instance RuleResult TypeCheck = TcModuleResult
 type instance RuleResult GetSpanInfo = [SpanInfo]
 
 -- | Convert to Core, requires TypeCheck*
-type instance RuleResult GenerateCore = CoreModule
+type instance RuleResult GenerateCore = (CoreModule, CompiledByteCode, [SptEntry])
+
+instance Show CompiledByteCode where
+    show _ = "<compiled byte code>"
+instance NFData CompiledByteCode where
+    rnf x = seq x ()
+instance Show SptEntry where
+    show _ = "<spt entry>"
+instance NFData SptEntry where
+    rnf x = seq x ()
 
 -- | A GHC session that we reuse.
 type instance RuleResult GhcSession = HscEnvEq

--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -24,7 +24,7 @@ import           GHC.Generics                             (Generic)
 
 import           GHC
 import Module (InstalledUnitId)
-import HscTypes (HomeModInfo)
+import HscTypes (CgGuts, Linkable, HomeModInfo, ModDetails)
 import Development.IDE.GHC.Compat
 
 import           Development.IDE.Spans.Type
@@ -65,7 +65,10 @@ type instance RuleResult TypeCheck = TcModuleResult
 type instance RuleResult GetSpanInfo = [SpanInfo]
 
 -- | Convert to Core, requires TypeCheck*
-type instance RuleResult GenerateCore = (CoreModule, TcModuleResult)
+type instance RuleResult GenerateCore = (SafeHaskellMode, CgGuts, ModDetails)
+
+-- | Generate byte code for template haskell.
+type instance RuleResult GenerateByteCode = Linkable
 
 -- | A GHC session that we reuse.
 type instance RuleResult GhcSession = HscEnvEq
@@ -130,6 +133,12 @@ data GenerateCore = GenerateCore
 instance Hashable GenerateCore
 instance NFData   GenerateCore
 instance Binary   GenerateCore
+
+data GenerateByteCode = GenerateByteCode
+   deriving (Eq, Show, Typeable, Generic)
+instance Hashable GenerateByteCode
+instance NFData   GenerateByteCode
+instance Binary   GenerateByteCode
 
 data GhcSession = GhcSession
     deriving (Eq, Show, Typeable, Generic)

--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -24,7 +24,7 @@ import           GHC.Generics                             (Generic)
 
 import           GHC
 import Module (InstalledUnitId)
-import HscTypes (HomeModInfo, CompiledByteCode, SptEntry)
+import HscTypes (HomeModInfo)
 import Development.IDE.GHC.Compat
 
 import           Development.IDE.Spans.Type

--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -65,16 +65,7 @@ type instance RuleResult TypeCheck = TcModuleResult
 type instance RuleResult GetSpanInfo = [SpanInfo]
 
 -- | Convert to Core, requires TypeCheck*
-type instance RuleResult GenerateCore = (CoreModule, CompiledByteCode, [SptEntry])
-
-instance Show CompiledByteCode where
-    show _ = "<compiled byte code>"
-instance NFData CompiledByteCode where
-    rnf x = seq x ()
-instance Show SptEntry where
-    show _ = "<spt entry>"
-instance NFData SptEntry where
-    rnf x = seq x ()
+type instance RuleResult GenerateCore = (CoreModule, TcModuleResult)
 
 -- | A GHC session that we reuse.
 type instance RuleResult GhcSession = HscEnvEq

--- a/src/Development/IDE/GHC/Orphans.hs
+++ b/src/Development/IDE/GHC/Orphans.hs
@@ -20,7 +20,13 @@ import Development.IDE.GHC.Util
 -- Orphan instances for types from the GHC API.
 instance Show CoreModule where show = prettyPrint
 instance NFData CoreModule where rnf = rwhnf
-
+instance Show CgGuts where show = prettyPrint . cg_module
+instance NFData CgGuts where rnf = rwhnf
+instance Show ModDetails where show = const "<moddetails>"
+instance NFData ModDetails where rnf = rwhnf
+instance NFData SafeHaskellMode where rnf = rwhnf
+instance Show Linkable where show = prettyPrint
+instance NFData Linkable where rnf = rwhnf
 
 instance Show InstalledUnitId where
     show = installedUnitIdString

--- a/src/Development/IDE/GHC/Util.hs
+++ b/src/Development/IDE/GHC/Util.hs
@@ -19,7 +19,8 @@ module Development.IDE.GHC.Util(
     textToStringBuffer,
     moduleImportPath,
     HscEnvEq, hscEnv, newHscEnvEq,
-    readFileUtf8
+    readFileUtf8,
+    cgGutsToCoreModule
     ) where
 
 import Config
@@ -146,3 +147,10 @@ instance NFData HscEnvEq where
 
 readFileUtf8 :: FilePath -> IO T.Text
 readFileUtf8 f = T.decodeUtf8With T.lenientDecode <$> BS.readFile f
+
+cgGutsToCoreModule :: SafeHaskellMode -> CgGuts -> ModDetails -> CoreModule
+cgGutsToCoreModule safeMode guts modDetails = CoreModule
+    (cg_module guts)
+    (md_types modDetails)
+    (cg_binds guts)
+    safeMode

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -839,7 +839,7 @@ thTests =
   testGroup
     "TemplateHaskell"
     [ -- Test for https://github.com/digital-asset/ghcide/pull/212
-      testSession "load" $ do
+      testSessionWait "load" $ do
         let sourceA =
               T.unlines
                 [ "{-# LANGUAGE PackageImports #-}",
@@ -857,12 +857,11 @@ thTests =
                   "import A",
                   "import \"template-haskell\" Language.Haskell.TH",
                   "b :: Integer",
-                  "b = $(litE $ IntegerL $ a)"
+                  "b = $(litE $ IntegerL $ a) + n"
                 ]
         _ <- openDoc' "A.hs" "haskell" sourceA
         _ <- openDoc' "B.hs" "haskell" sourceB
-        _ <- waitForDiagnostics
-        expectDiagnostics [ ( "B.hs", [] ) ]
+        expectDiagnostics [ ( "B.hs", [(DsError, (6, 29), "Variable not in scope: n")] ) ]
     ]
 
 xfail :: TestTree -> String -> TestTree

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -41,6 +41,7 @@ main = defaultMain $ testGroup "HIE"
   , codeActionTests
   , findDefinitionAndHoverTests
   , pluginTests
+  , thTests
   ]
 
 initializeResponseTests :: TestTree
@@ -831,6 +832,37 @@ pluginTests = testSessionWait "plugins" $ do
     [ ( "Testing.hs",
         [(DsError, (8, 14), "Variable not in scope: c")]
       )
+    ]
+
+thTests :: TestTree
+thTests =
+  testGroup
+    "TemplateHaskell"
+    [ -- Test for https://github.com/digital-asset/ghcide/pull/212
+      testSession "load" $ do
+        let sourceA =
+              T.unlines
+                [ "{-# LANGUAGE PackageImports #-}",
+                  "{-# LANGUAGE TemplateHaskell #-}",
+                  "module A where",
+                  "import \"template-haskell\" Language.Haskell.TH",
+                  "a :: Integer",
+                  "a = $(litE $ IntegerL 3)"
+                ]
+            sourceB =
+              T.unlines
+                [ "{-# LANGUAGE PackageImports #-}",
+                  "{-# LANGUAGE TemplateHaskell #-}",
+                  "module B where",
+                  "import A",
+                  "import \"template-haskell\" Language.Haskell.TH",
+                  "b :: Integer",
+                  "b = $(litE $ IntegerL $ a)"
+                ]
+        _ <- openDoc' "A.hs" "haskell" sourceA
+        _ <- openDoc' "B.hs" "haskell" sourceB
+        _ <- waitForDiagnostics
+        expectDiagnostics [ ( "B.hs", [] ) ]
     ]
 
 xfail :: TestTree -> String -> TestTree


### PR DESCRIPTION
This is a first attempt to fix #34. Right now, things seem to work fine, at least examples do! :)

There are a few things that might need additional attention:
- Right now all modules are compiled to bytecode, because they might be needed in the future. Could we be more precise on this, to avoid having to generate all that code?
- When a file is read by TemplateHaskell, it assumes that the current directory is the one in which `ghcide` is run. This is different from what Stack or Cabal do, because they assume the `hs-source-dirs` of the project is the current directory. This means files cannot be loaded correctly by TemplateHaskell splices in `ghcide`.