### PR TITLE
Code lens for missing signatures

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -48,7 +48,6 @@ library
         prettyprinter-ansi-terminal,
         prettyprinter-ansi-terminal,
         prettyprinter,
-        random,
         rope-utf16-splay,
         safe-exceptions,
         shake >= 0.17.5,

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -48,6 +48,7 @@ library
         prettyprinter-ansi-terminal,
         prettyprinter-ansi-terminal,
         prettyprinter,
+        random,
         rope-utf16-splay,
         safe-exceptions,
         shake >= 0.17.5,

--- a/src/Development/IDE/LSP/CodeAction.hs
+++ b/src/Development/IDE/LSP/CodeAction.hs
@@ -8,18 +8,22 @@
 -- | Go to the definition of a variable.
 module Development.IDE.LSP.CodeAction
     ( setHandlersCodeAction
+    , setHandlersCodeLens
     ) where
 
 import           Language.Haskell.LSP.Types
 import Development.IDE.GHC.Compat
 import Development.IDE.Core.Rules
+import Development.IDE.Core.Shake
 import Development.IDE.LSP.Server
+import Development.IDE.Types.Location
 import qualified Data.HashMap.Strict as Map
 import qualified Data.HashSet as Set
 import qualified Language.Haskell.LSP.Core as LSP
 import Language.Haskell.LSP.VFS
 import Language.Haskell.LSP.Messages
 import qualified Data.Rope.UTF16 as Rope
+import Data.Aeson.Types (toJSON, fromJSON, Value(..), Result(..))
 import Data.Char
 import Data.Maybe
 import Data.List.Extra
@@ -42,9 +46,41 @@ codeAction lsp _ CodeActionParams{_textDocument=TextDocumentIdentifier uri,_cont
         , let edit = WorkspaceEdit (Just $ Map.singleton uri $ List tedit) Nothing
         ]
 
+-- | Generate code lenses.
+codeLens
+    :: LSP.LspFuncs ()
+    -> IdeState
+    -> CodeLensParams
+    -> IO (List CodeLens)
+codeLens _lsp ideState CodeLensParams{_textDocument=TextDocumentIdentifier uri} = do
+    diag <- getDiagnostics ideState
+    case uriToFilePath' uri of
+      Just (toNormalizedFilePath -> filePath) -> do
+        pure $ List
+          [ CodeLens _range (Just (Command title "typesignature.add" (Just $ List [toJSON edit]))) Nothing
+          | (dFile, dDiag@Diagnostic{_range=_range@Range{..},..}) <- diag
+          , dFile == filePath
+          , (title, tedit) <- suggestTopLevelBinding dDiag
+          , let edit = WorkspaceEdit (Just $ Map.singleton uri $ List tedit) Nothing
+          ]
+      Nothing -> pure $ List []
+
+-- | Generate code lenses.
+executeAddSignatureCommand
+    :: LSP.LspFuncs ()
+    -> IdeState
+    -> ExecuteCommandParams
+    -> IO (Value, Maybe (ServerMethod, ApplyWorkspaceEditParams))
+executeAddSignatureCommand _lsp _ideState ExecuteCommandParams{..}
+    | _command == "typesignature.add"
+    , Just (List [edit]) <- _arguments
+    , Success wedit <- fromJSON edit 
+    = return (Null, Just (WorkspaceApplyEdit, ApplyWorkspaceEditParams wedit))
+    | otherwise
+    = return (Null, Nothing)
 
 suggestAction :: Maybe T.Text -> Diagnostic -> [(T.Text, [TextEdit])]
-suggestAction contents Diagnostic{_range=_range@Range{..},..}
+suggestAction contents diag@Diagnostic{_range=_range@Range{..},..}
 
 -- File.hs:16:1: warning:
 --     The import of `Data.List' is redundant
@@ -141,6 +177,12 @@ suggestAction contents Diagnostic{_range=_range@Range{..},..}
       extractFitNames     = map (T.strip . head . T.splitOn " :: ")
       in map proposeHoleFit $ nubOrd $ findSuggestedHoleFits _message
 
+    | tlb@[_] <- suggestTopLevelBinding diag = tlb
+
+suggestAction _ _ = []
+
+suggestTopLevelBinding :: Diagnostic -> [(T.Text, [TextEdit])]
+suggestTopLevelBinding Diagnostic{_range=_range@Range{..},..}
     | "Top-level binding with no type signature" `T.isInfixOf` _message = let
       filterNewlines = T.concat  . T.lines
       unifySpaces    = T.unwords . T.words
@@ -150,8 +192,7 @@ suggestAction contents Diagnostic{_range=_range@Range{..},..}
       title          = "add signature: " <> signature
       action         = TextEdit beforeLine $ signature <> "\n"
       in [(title, [action])]
-
-suggestAction _ _ = []
+suggestTopLevelBinding _ = []
 
 topOfHoleFitsMarker :: T.Text
 topOfHoleFitsMarker =
@@ -235,4 +276,10 @@ textInRange (Range (Position startRow startCol) (Position endRow endCol)) text =
 setHandlersCodeAction :: PartialHandlers
 setHandlersCodeAction = PartialHandlers $ \WithMessage{..} x -> return x{
     LSP.codeActionHandler = withResponse RspCodeAction codeAction
+    }
+
+setHandlersCodeLens :: PartialHandlers
+setHandlersCodeLens = PartialHandlers $ \WithMessage{..} x -> return x{
+    LSP.codeLensHandler = withResponse RspCodeLens codeLens,
+    LSP.executeCommandHandler = withResponseAndRequest RspExecuteCommand ReqApplyWorkspaceEdit executeAddSignatureCommand
     }

--- a/src/Development/IDE/LSP/Server.hs
+++ b/src/Development/IDE/LSP/Server.hs
@@ -26,6 +26,12 @@ data WithMessage = WithMessage
         Maybe (LSP.Handler (NotificationMessage m req)) -> -- old notification handler
         (LSP.LspFuncs () -> IdeState -> req -> IO ()) -> -- actual work
         Maybe (LSP.Handler (NotificationMessage m req))
+    ,withResponseAndRequest :: forall m rm req resp newReqParams newReqBody. 
+        (Show m, Show rm, Show req, Show newReqParams, Show newReqBody) =>
+        (ResponseMessage resp -> LSP.FromServerMessage) -> -- how to wrap a response
+        (RequestMessage rm newReqParams newReqBody -> LSP.FromServerMessage) -> -- how to wrap the additional req
+        (LSP.LspFuncs () -> IdeState -> req -> IO (resp, Maybe (rm, newReqParams))) -> -- actual work
+        Maybe (LSP.Handler (RequestMessage m req resp))
     }
 
 newtype PartialHandlers = PartialHandlers (WithMessage -> LSP.Handlers -> IO LSP.Handlers)

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -66,7 +66,7 @@ initializeResponseTests = withResource acquire release tests where
     , chk "NO doc symbol"           _documentSymbolProvider  Nothing
     , chk "NO workspace symbol"    _workspaceSymbolProvider  Nothing
     , chk "   code action"             _codeActionProvider $ Just $ CodeActionOptionsStatic True
-    , chk "NO code lens"                  _codeLensProvider  Nothing
+    , chk "   code lens"                 _codeLensProvider $ Just $ CodeLensOptions Nothing
     , chk "NO doc formatting"   _documentFormattingProvider  Nothing
     , chk "NO doc range formatting"
                            _documentRangeFormattingProvider  Nothing
@@ -76,7 +76,7 @@ initializeResponseTests = withResource acquire release tests where
     , chk "NO doc link"               _documentLinkProvider  Nothing
     , chk "NO color"                         _colorProvider (Just $ ColorOptionsStatic False)
     , chk "NO folding range"          _foldingRangeProvider (Just $ FoldingRangeOptionsStatic False)
-    , chk "NO execute command"      _executeCommandProvider  Nothing
+    , chk "   execute command"      _executeCommandProvider (Just $ ExecuteCommandOptions $ List ["typesignature.add"])
     , chk "NO workspace"                         _workspace  nothingWorkspace
     , chk "NO experimental"                   _experimental  Nothing
     ] where


### PR DESCRIPTION
This PR adds code lenses for missing type signatures, as discussed in #88. Missing type signatures appear as comments on top of the start of the definition, as shown in [this image](https://imgur.com/a/KcQpagl). When the user clicks on the definition, it's added to the source code.

Unfortunately, the [specification of code lenses](https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_codeLens) is not as straightforward as code actions. Instead of returning how to edit the file directly, we need to return an identifier with a command, which is then called when the user clicks on the code lens. That command does not return what to do either, instead it may request things from the client by using a server request. Hence the need for a new type of response in `WithMessage`, with both the response to the request and an optional user request. This new constructor might be merged with `withResponse`, but I didn't take that step; let me know if you prefer me to do so.