### PR TITLE
Fix horrible path normalisation issue

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -167,9 +167,11 @@ loadSession :: FilePath -> IO (FilePath -> Action HscEnvEq)
 loadSession dir = do
     cradleLoc <- memoIO $ \v -> do
         res <- findCradle v
-        -- Sometimes we get C: and sometimes we get c:, try and normalise that
+        -- Sometimes we get C:, sometimes we get c:, and sometimes we get a relative path
+        -- try and normalise that
         -- e.g. see https://github.com/digital-asset/ghcide/issues/126
-        return $ normalise <$> res
+        res' <- traverse makeAbsolute res
+        return $ normalise <$> res'
     session <- memoIO $ \file -> do
         c <- maybe (loadImplicitCradle $ addTrailingPathSeparator dir) loadCradle file
         cradleToSession c


### PR DESCRIPTION
Not sure why sometimes the path to the cradle is absolute and other times it's relative. Using Linux and direct cradles, happens both on Emacs and Code. 

Because of this issue, ghcide v0.4 is broken for me on certain files both on personal projects and at work. 