### PR TITLE
Workaround hDuplicateTo issues

### DIFF
--- a/src/Development/IDE/LSP/LanguageServer.hs
+++ b/src/Development/IDE/LSP/LanguageServer.hs
@@ -12,6 +12,7 @@ module Development.IDE.LSP.LanguageServer
 import           Language.Haskell.LSP.Types
 import           Language.Haskell.LSP.Types.Capabilities
 import           Development.IDE.LSP.Server
+import qualified Development.IDE.GHC.Util as Ghcide
 import qualified Language.Haskell.LSP.Control as LSP
 import qualified Language.Haskell.LSP.Core as LSP
 import Control.Concurrent.Chan
@@ -23,7 +24,7 @@ import Data.Default
 import Data.Maybe
 import qualified Data.Set as Set
 import qualified Data.Text as T
-import           GHC.IO.Handle                    (hDuplicate, hDuplicateTo)
+import GHC.IO.Handle (hDuplicate)
 import System.IO
 import Control.Monad.Extra
 
@@ -37,7 +38,6 @@ import Development.IDE.Core.FileStore
 import Language.Haskell.LSP.Core (LspFuncs(..))
 import Language.Haskell.LSP.Messages
 
-
 runLanguageServer
     :: LSP.Options
     -> PartialHandlers
@@ -48,7 +48,7 @@ runLanguageServer options userHandlers getIdeState = do
     -- to stdout. This guards against stray prints from corrupting the JSON-RPC
     -- message stream.
     newStdout <- hDuplicate stdout
-    stderr `hDuplicateTo` stdout
+    stderr `Ghcide.hDuplicateTo` stdout
     hSetBuffering stderr NoBuffering
     hSetBuffering stdout NoBuffering
 


### PR DESCRIPTION
We have seen a bunch of failures on CI where this failed with
EBUSY. I find the hDuplicateTo here to be quite useful for debugging
since you don’t have to worry about corrupting the JSON-RPC stream to
instead of getting rid of it, we add a somewhat ugly workaround.

There is an explanation in an inline comment on why this helps but
admittedly I am somewhat guessing since I don’t understand what is
actually allocating the file descriptor that turns out to be
stdout. That said, I am not guessing on the results: Without this PR I
am able to make this fail in roughly 50% of the cases on CI whereas
with this PR, I’ve now run it 60 times on CI without a single failure.