### PR TITLE
Fix #237

### DIFF
--- a/src/Development/IDE/Spans/Calculate.hs
+++ b/src/Development/IDE/Spans/Calculate.hs
@@ -74,7 +74,7 @@ getSpanInfo mods tcm =
   where cmp (_,a,_) (_,b,_)
           | a `isSubspanOf` b = LT
           | b `isSubspanOf` a = GT
-          | otherwise = EQ
+          | otherwise         = compare (srcSpanStart a) (srcSpanStart b)
 
 getExports :: TypecheckedModule -> [(SpanSource, SrcSpan, Maybe Type)]
 getExports m

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -810,9 +810,9 @@ findDefinitionAndHoverTests = let
   , test yes    broken clL23  cls    "class in instance declaration"
   , test yes    broken clL25  cls    "class in signature"            -- 147
   , test broken broken eclL15 ecls   "external class in signature"
-  , test yes    broken dnbL29 dnb    "do-notation   bind"            -- 137
+  , test yes    yes    dnbL29 dnb    "do-notation   bind"            -- 137
   , test yes    yes    dnbL30 dnb    "do-notation lookup"
-  , test yes    broken lcbL33 lcb    "listcomp   bind"               -- 137
+  , test yes    yes    lcbL33 lcb    "listcomp   bind"               -- 137
   , test yes    yes    lclL33 lcb    "listcomp lookup"
   ]
   where yes, broken :: (TestTree -> Maybe TestTree)


### PR DESCRIPTION
The bug was caused by broken transitivity of the comparison function used to
sort spans. Nested spans were meant to be sorted in innermost-first order, with
the first (innermost) one being used to get type information about the symbol at
a given position.

Because the comparison function considered any two non-nested spans to be EQ,
the sort could incorrectly conclude (by transitivity) that two nested spans were
equal, and thus leave them in incorrect relative order. This resulted in the
innermost span sometimes not appearing at the front of the list of spans which
enclose a given point, and hover reporting the type of a bigger expression in
which the point appeared.

The solution imposes ordering on non-nested spans by comparing their starting
positions, thus fixing transitivity.

Fixes #237 (... probably along with a bunch of other little bugs caused by the
same mistake).