### PR TITLE
Filter out completely warnings not enabled by user

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -150,7 +150,7 @@ kick = do
 showEvent :: Lock -> FromServerMessage -> IO ()
 showEvent _ (EventFileDiagnostics _ []) = return ()
 showEvent lock (EventFileDiagnostics (toNormalizedFilePath -> file) diags) =
-    withLock lock $ T.putStrLn $ showDiagnosticsColored $ map (file,) diags
+    withLock lock $ T.putStrLn $ showDiagnosticsColored $ map (file,ShowDiag,) diags
 showEvent lock e = withLock lock $ print e
 
 

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -229,7 +229,7 @@ reportImportCyclesRule =
     where cycleErrorInFile f (PartOfCycle imp fs)
             | f `elem` fs = Just (imp, fs)
           cycleErrorInFile _ _ = Nothing
-          toDiag imp mods = (fp ,) $ Diagnostic
+          toDiag imp mods = (fp , ShowDiag , ) $ Diagnostic
             { _range = (_range :: Location -> Range) loc
             , _severity = Just DsError
             , _source = Just "Import cycle detection"

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -28,6 +28,7 @@ module Development.IDE.Core.Shake(
     use_, useNoFile_, uses_,
     define, defineEarlyCutoff, defineOnDisk, needOnDisk, needOnDisks, fingerprintToBS,
     getDiagnostics, unsafeClearDiagnostics,
+    getHiddenDiagnostics,
     IsIdeGlobal, addIdeGlobal, getIdeGlobalState, getIdeGlobalAction,
     garbageCollect,
     setPriority,
@@ -93,6 +94,7 @@ data ShakeExtras = ShakeExtras
     ,globals :: Var (HMap.HashMap TypeRep Dynamic)
     ,state :: Var Values
     ,diagnostics :: Var DiagnosticStore
+    ,hiddenDiagnostics :: Var DiagnosticStore
     ,publishedDiagnostics :: Var (Map NormalizedUri [Diagnostic])
     -- ^ This represents the set of diagnostics that we have published.
     -- Due to debouncing not every change might get published.
@@ -289,6 +291,7 @@ shakeOpen getLspId eventer logger shakeProfileDir (IdeReportProgress reportProgr
         globals <- newVar HMap.empty
         state <- newVar HMap.empty
         diagnostics <- newVar mempty
+        hiddenDiagnostics <- newVar mempty
         publishedDiagnostics <- newVar mempty
         debouncer <- newDebouncer
         positionMapping <- newVar Map.empty
@@ -400,6 +403,11 @@ getDiagnostics IdeState{shakeExtras = ShakeExtras{diagnostics}} = do
     val <- readVar diagnostics
     return $ getAllDiagnostics val
 
+getHiddenDiagnostics :: IdeState -> IO [FileDiagnostic]
+getHiddenDiagnostics IdeState{shakeExtras = ShakeExtras{hiddenDiagnostics}} = do
+    val <- readVar hiddenDiagnostics
+    return $ getAllDiagnostics val
+
 -- | FIXME: This function is temporary! Only required because the files of interest doesn't work
 unsafeClearDiagnostics :: IdeState -> IO ()
 unsafeClearDiagnostics IdeState{shakeExtras = ShakeExtras{diagnostics}} =
@@ -408,12 +416,13 @@ unsafeClearDiagnostics IdeState{shakeExtras = ShakeExtras{diagnostics}} =
 -- | Clear the results for all files that do not match the given predicate.
 garbageCollect :: (NormalizedFilePath -> Bool) -> Action ()
 garbageCollect keep = do
-    ShakeExtras{state, diagnostics,publishedDiagnostics,positionMapping} <- getShakeExtras
+    ShakeExtras{state, diagnostics,hiddenDiagnostics,publishedDiagnostics,positionMapping} <- getShakeExtras
     liftIO $
         do newState <- modifyVar state $ \values -> do
                values <- evaluate $ HMap.filterWithKey (\(file, _) _ -> keep file) values
                return $! dupe values
            modifyVar_ diagnostics $ \diags -> return $! filterDiagnostics keep diags
+           modifyVar_ hiddenDiagnostics $ \hdiags -> return $! filterDiagnostics keep hdiags
            modifyVar_ publishedDiagnostics $ \diags -> return $! Map.filterWithKey (\uri _ -> keep (fromUri uri)) diags
            let versionsForFile =
                    Map.fromListWith Set.union $
@@ -528,7 +537,7 @@ defineEarlyCutoff op = addBuiltinRule noLint noIdentity $ \(Q (key, file)) (old 
                             Failed -> (toShakeValue ShakeResult bs, Failed)
                 Just v -> pure $ (maybe ShakeNoCutoff ShakeResult bs, Succeeded (vfsVersion =<< modTime) v)
             liftIO $ setValues state key file res
-            updateFileDiagnostics file (Key key) extras $ map snd diags
+            updateFileDiagnostics file (Key key) extras $ map (\(_,y,z) -> (y,z)) diags
             let eq = case (bs, fmap decodeShakeValue old) of
                     (ShakeResult a, Just (ShakeResult b)) -> a == b
                     (ShakeStale a, Just (ShakeStale b)) -> a == b
@@ -589,7 +598,7 @@ defineOnDisk act = addBuiltinRule noLint noIdentity $
       case mbOld of
           Nothing -> do
               (diags, mbHash) <- runAct
-              updateFileDiagnostics file (Key key) extras $ map snd diags
+              updateFileDiagnostics file (Key key) extras $ map (\(_,y,z) -> (y,z)) diags
               pure $ RunResult ChangedRecomputeDiff (fromMaybe "" mbHash) (isJust mbHash)
           Just old -> do
               current <- validateHash <$> (actionCatch getHash $ \(_ :: SomeException) -> pure "")
@@ -600,7 +609,7 @@ defineOnDisk act = addBuiltinRule noLint noIdentity $
                     pure $ RunResult ChangedNothing (fromMaybe "" current) (isJust current)
                   else do
                     (diags, mbHash) <- runAct
-                    updateFileDiagnostics file (Key key) extras $ map snd diags
+                    updateFileDiagnostics file (Key key) extras $ map (\(_,y,z) -> (y,z)) diags
                     let change
                           | mbHash == Just old = ChangedRecomputeSame
                           | otherwise = ChangedRecomputeDiff
@@ -656,17 +665,26 @@ updateFileDiagnostics ::
      NormalizedFilePath
   -> Key
   -> ShakeExtras
-  -> [Diagnostic] -- ^ current results
+  -> [(ShowDiagnostic,Diagnostic)] -- ^ current results
   -> Action ()
-updateFileDiagnostics fp k ShakeExtras{diagnostics, publishedDiagnostics, state, debouncer, eventer} current = liftIO $ do
+updateFileDiagnostics fp k ShakeExtras{diagnostics, hiddenDiagnostics, publishedDiagnostics, state, debouncer, eventer} current = liftIO $ do
     modTime <- join . fmap currentValue <$> getValues state GetModificationTime fp
+    let (currentShown, currentHidden) = partition ((== ShowDiag) . fst) current
     mask_ $ do
         -- Mask async exceptions to ensure that updated diagnostics are always
         -- published. Otherwise, we might never publish certain diagnostics if
         -- an exception strikes between modifyVar but before
         -- publishDiagnosticsNotification.
         newDiags <- modifyVar diagnostics $ \old -> do
-            let newDiagsStore = setStageDiagnostics fp (vfsVersion =<< modTime) (T.pack $ show k) current old
+            let newDiagsStore = setStageDiagnostics fp (vfsVersion =<< modTime)
+                                  (T.pack $ show k) (map snd currentShown) old
+            let newDiags = getFileDiagnostics fp newDiagsStore
+            _ <- evaluate newDiagsStore
+            _ <- evaluate newDiags
+            pure $! (newDiagsStore, newDiags)
+        _newHiddenDiags <- modifyVar hiddenDiagnostics $ \old -> do
+            let newDiagsStore = setStageDiagnostics fp (vfsVersion =<< modTime)
+                                  (T.pack $ show k) (map snd currentHidden) old
             let newDiags = getFileDiagnostics fp newDiagsStore
             _ <- evaluate newDiagsStore
             _ <- evaluate newDiags
@@ -751,7 +769,7 @@ getAllDiagnostics ::
     DiagnosticStore ->
     [FileDiagnostic]
 getAllDiagnostics =
-    concatMap (\(k,v) -> map (fromUri k,) $ getDiagnosticsFromStore v) . Map.toList
+    concatMap (\(k,v) -> map (fromUri k,ShowDiag,) $ getDiagnosticsFromStore v) . Map.toList
 
 getFileDiagnostics ::
     NormalizedFilePath ->

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -682,13 +682,13 @@ updateFileDiagnostics fp k ShakeExtras{diagnostics, hiddenDiagnostics, published
             _ <- evaluate newDiagsStore
             _ <- evaluate newDiags
             pure $! (newDiagsStore, newDiags)
-        _newHiddenDiags <- modifyVar hiddenDiagnostics $ \old -> do
+        modifyVar_ hiddenDiagnostics $ \old -> do
             let newDiagsStore = setStageDiagnostics fp (vfsVersion =<< modTime)
                                   (T.pack $ show k) (map snd currentHidden) old
             let newDiags = getFileDiagnostics fp newDiagsStore
             _ <- evaluate newDiagsStore
             _ <- evaluate newDiags
-            pure $! (newDiagsStore, newDiags)
+            return newDiagsStore
         let uri = filePathToUri' fp
         let delay = if null newDiags then 0.1 else 0
         registerEvent debouncer delay uri $ do

--- a/src/Development/IDE/GHC/Error.hs
+++ b/src/Development/IDE/GHC/Error.hs
@@ -34,7 +34,7 @@ import qualified Outputable                 as Out
 
 
 diagFromText :: T.Text -> D.DiagnosticSeverity -> SrcSpan -> T.Text -> FileDiagnostic
-diagFromText diagSource sev loc msg = (toNormalizedFilePath $ srcSpanToFilename loc,)
+diagFromText diagSource sev loc msg = (toNormalizedFilePath $ srcSpanToFilename loc,ShowDiag,)
     Diagnostic
     { _range    = srcSpanToRange loc
     , _severity = Just sev

--- a/src/Development/IDE/LSP/CodeAction.hs
+++ b/src/Development/IDE/LSP/CodeAction.hs
@@ -59,9 +59,10 @@ codeLens _lsp ideState CodeLensParams{_textDocument=TextDocumentIdentifier uri} 
       Just (toNormalizedFilePath -> filePath) -> do
         _ <- runAction ideState $ runMaybeT $ useE TypeCheck filePath
         diag <- getDiagnostics ideState
+        hDiag <- getHiddenDiagnostics ideState
         pure $ List
           [ CodeLens _range (Just (Command title "typesignature.add" (Just $ List [toJSON edit]))) Nothing
-          | (dFile, dDiag@Diagnostic{_range=_range@Range{..},..}) <- diag
+          | (dFile, _, dDiag@Diagnostic{_range=_range@Range{..},..}) <- diag ++ hDiag
           , dFile == filePath
           , (title, tedit) <- suggestSignature False dDiag
           , let edit = WorkspaceEdit (Just $ Map.singleton uri $ List tedit) Nothing

--- a/src/Development/IDE/Types/Diagnostics.hs
+++ b/src/Development/IDE/Types/Diagnostics.hs
@@ -41,8 +41,16 @@ ideErrorText fp msg = (fp, ShowDiag, LSP.Diagnostic {
     _relatedInformation = Nothing
     })
 
+-- | Defines whether a particular diagnostic should be reported
+--   back to the user.
+--
+--   One important use case is "missing signature" code lenses,
+--   for which we need to enable the corresponding warning during
+--   type checking. However, we do not want to show the warning
+--   unless the programmer asks for it (#261).
 data ShowDiagnostic
-    = ShowDiag | HideDiag
+    = ShowDiag  -- ^ Report back to the user
+    | HideDiag  -- ^ Hide from user
     deriving (Eq, Ord, Show)
 
 instance NFData ShowDiagnostic where

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -719,10 +719,9 @@ addSigLensesTests = let
     let originalCode = before withMissing def
     let expectedCode = after' withMissing def sig
     doc <- openDoc' "Sigs.hs" "haskell" originalCode
-    _ <- waitForDiagnostics
     [CodeLens {_command = Just c}] <- getCodeLenses doc
     executeCommand c
-    modifiedCode <- documentContents doc
+    modifiedCode <- getDocumentEdit doc
     liftIO $ expectedCode @=? modifiedCode
   in
   testGroup "add signature"


### PR DESCRIPTION
This is another attempt at fixing the problems described by #261. After this patch, warnings which were not enabled explicitly by the user but are needed to support some other functionality (mainly code lenses) are completely filtered out.

The implementation works by keeping two `DiagnosticStore`s in the `IdeState`: the usual one, and a new one of "hidden diagnostics". The means that a call to `getDiagnostics` should do the right thing and show only those warnings which were enabled. You need to call `getHiddenDiagnostics` to obtain the rest of the diagnostics, as done in the code lens code.