### PR TITLE
Define "__GHCIDE__" on CPP

### DIFF
--- a/src/Development/IDE/GHC/CPP.hs
+++ b/src/Development/IDE/GHC/CPP.hs
@@ -114,6 +114,8 @@ doCpp dflags raw input_fn output_fn = do
                     ++ map SysTools.Option sse_defs
                     ++ map SysTools.Option avx_defs
                     ++ mb_macro_include
+        -- Define a special macro "__GHCIDE__"
+                    ++ [ SysTools.Option "-D__GHCIDE__"]
         -- Set the language mode to assembler-with-cpp when preprocessing. This
         -- alleviates some of the C99 macro rules relating to whitespace and the hash
         -- operator, which we tend to abuse. Clang in particular is not very happy


### PR DESCRIPTION
This patch comes from my experience in using ghcide in combination with quasi-quoters which read from files. If you have something like:

```haskell
$(doSomething "from.file")
```

then build tools would take the relative path to start with the source folder of the corresponding project, but ghcide takes it from the root of the project. Until a better solution is found, my proposal is to have this additional define in CPP, so we can do:

```haskell
#if __GHCIDE__
$(doSomething "src/from.file")
#else
$(doSomething "from.file")
#endif
```