### PR TITLE
Make hie.yaml hie-bios-0.3 compatible

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,1 +1,1 @@
-cradle: {stack}
+cradle: {stack: {component: "ghcide:lib"}}


### PR DESCRIPTION
Seems to be required or I get errors about Stack not being able to pick flags. I guess this is a hie-bios-0.3 change.