### PR TITLE
#279, support preprocessors

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -131,6 +131,14 @@ library
         Development.IDE.Spans.Type
     ghc-options: -Wall -Wno-name-shadowing
 
+executable ghcide-test-preprocessor
+    default-language: Haskell2010
+    hs-source-dirs: test/preprocessor
+    ghc-options: -Wall
+    main-is: Main.hs
+    build-depends:
+        base == 4.*
+
 executable ghcide
     if flag(ghc-lib)
       buildable: False

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -177,7 +177,8 @@ test-suite ghcide-tests
     type: exitcode-stdio-1.0
     default-language: Haskell2010
     build-tool-depends:
-        ghcide:ghcide
+        ghcide:ghcide,
+        ghcide:ghcide-test-preprocessor
     build-depends:
         base,
         bytestring,

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -42,6 +42,7 @@ main = defaultMain $ testGroup "HIE"
   , codeLensesTests
   , findDefinitionAndHoverTests
   , pluginTests
+  , preprocessorTests
   , thTests
   ]
 
@@ -909,6 +910,21 @@ pluginTests = testSessionWait "plugins" $ do
   expectDiagnostics
     [ ( "Testing.hs",
         [(DsError, (8, 14), "Variable not in scope: c")]
+      )
+    ]
+
+preprocessorTests :: TestTree
+preprocessorTests = testSessionWait "preprocessor" $ do
+  let content =
+        T.unlines
+          [ "{-# OPTIONS_GHC -F -pgmF=ghcide-test-preprocessor #-}"
+          , "module Testing where"
+          , "y = x + z" -- plugin replaces x with y, making this have only one diagnostic
+          ]
+  _ <- openDoc' "Testing.hs" "haskell" content
+  expectDiagnostics
+    [ ( "Testing.hs",
+        [(DsError, (2, 8), "Variable not in scope: z")]
       )
     ]
 

--- a/test/preprocessor/Main.hs
+++ b/test/preprocessor/Main.hs
@@ -1,0 +1,10 @@
+
+module Main(main) where
+
+import System.Environment
+
+main :: IO ()
+main = do
+    _:input:output:_ <- getArgs
+    let f = map (\x -> if x == 'x' then 'y' else x)
+    writeFile output . f =<< readFile input


### PR DESCRIPTION
Turns out to be rather easy, since GHC exposes very reusable pieces. Works with the example in #279. CC @DoctorRyner

I don't have a great suggestion for how to test this, but I do think a test would be valuable. To do a test we need a preprocessor available with the test suite. We could require record-dot-preprocessor, but that seems a very bad idea. We could write our own small shell script, but that's going to have portability issues. Thoughts?