### PR TITLE
Require hie-bios 0.3.2 or above

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -163,7 +163,7 @@ executable ghcide
         ghc-paths,
         ghc,
         haskell-lsp,
-        hie-bios >= 0.3 && < 0.4,
+        hie-bios >= 0.3.2 && < 0.4,
         ghcide,
         optparse-applicative,
         shake,

--- a/stack-ghc-lib.yaml
+++ b/stack-ghc-lib.yaml
@@ -4,8 +4,8 @@ packages:
 extra-deps:
 - haskell-lsp-0.19.0.0
 - haskell-lsp-types-0.19.0.0
-- lsp-test-0.9.0.0
-- hie-bios-0.3.0
+- lsp-test-0.10.0.0
+- hie-bios-0.3.2
 - ghc-lib-parser-8.8.1
 - ghc-lib-8.8.1
 - fuzzy-0.1.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,11 @@
-resolver: nightly-2019-09-16
+resolver: nightly-2019-09-21
 packages:
 - .
 extra-deps:
 - haskell-lsp-0.19.0.0
 - haskell-lsp-types-0.19.0.0
-- lsp-test-0.9.0.0
-- hie-bios-0.3.0
+- lsp-test-0.10.0.0
+- hie-bios-0.3.2
 - fuzzy-0.1.0.0
 - regex-base-0.94.0.0
 - regex-tdfa-1.3.1.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,5 +9,6 @@ extra-deps:
 - fuzzy-0.1.0.0
 - regex-base-0.94.0.0
 - regex-tdfa-1.3.1.0
+- parser-combinators-1.2.1
 nix:
   packages: [zlib]

--- a/stack84.yaml
+++ b/stack84.yaml
@@ -14,6 +14,7 @@ extra-deps:
 - fuzzy-0.1.0.0
 - regex-base-0.94.0.0
 - regex-tdfa-1.3.1.0
+- parser-combinators-1.2.1
 nix:
   packages: [zlib]
 allow-newer: true

--- a/stack84.yaml
+++ b/stack84.yaml
@@ -5,12 +5,12 @@ packages:
 extra-deps:
 - haskell-lsp-0.19.0.0
 - haskell-lsp-types-0.19.0.0
-- lsp-test-0.9.0.0
+- lsp-test-0.10.0.0
 - rope-utf16-splay-0.3.1.0
 - shake-0.18.3
 - filepattern-0.1.1
 - js-dgtable-0.5.2
-- hie-bios-0.3.0
+- hie-bios-0.3.2
 - fuzzy-0.1.0.0
 - regex-base-0.94.0.0
 - regex-tdfa-1.3.1.0

--- a/stack88.yaml
+++ b/stack88.yaml
@@ -1,14 +1,9 @@
-resolver: nightly-2019-12-06
+resolver: nightly-2020-01-03
 packages:
 - .
 extra-deps:
-- haskell-lsp-0.19.0.0
-- haskell-lsp-types-0.19.0.0
-- lsp-test-0.9.0.0
-- hie-bios-0.3.0
+- hie-bios-0.3.2
 - fuzzy-0.1.0.0
-- regex-base-0.94.0.0
-- regex-tdfa-1.3.1.0
 allow-newer: true
 nix:
   packages: [zlib]


### PR DESCRIPTION
Lower versions are pretty horribly broken on Windows. Require a fixed hie-bios to avoid support questions. Closes #281.