### PR TITLE
Fix for #45 - remove redundant symbols from imports

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -49,6 +49,7 @@ library
         prettyprinter-ansi-terminal,
         prettyprinter-ansi-terminal,
         prettyprinter,
+        regex-tdfa >= 1.3.1.0,
         rope-utf16-splay,
         safe-exceptions,
         shake >= 0.17.5,

--- a/src/Development/IDE/LSP/CodeAction.hs
+++ b/src/Development/IDE/LSP/CodeAction.hs
@@ -327,7 +327,7 @@ dropBindingsFromImportLine bindings_ importLine =
 
       filtering x = case () of
         () | x `elem` bindings -> Nothing
-        () | x `elem` (map (<> ")") bindings) -> Just ")"
+        () | x `elem` map (<> ")") bindings -> Just ")"
         _                      -> Just x
 
       joinCloseParens (x : ")" : rest) = (x <> ")") : joinCloseParens rest

--- a/src/Development/IDE/LSP/CodeAction.hs
+++ b/src/Development/IDE/LSP/CodeAction.hs
@@ -88,7 +88,7 @@ executeAddSignatureCommand _lsp _ideState ExecuteCommandParams{..}
 suggestAction :: Maybe T.Text -> Diagnostic -> [(T.Text, [TextEdit])]
 suggestAction contents diag@Diagnostic{_range=_range@Range{..},..}
 --     The qualified import of ‘many’ from module ‘Control.Applicative’ is redundant
-    | Just [_, bindings] <- matchRegex _message ("The( qualified)? import of ‘([^’]*)’ from module [^ ]* is redundant")
+    | Just [_, bindings] <- matchRegex _message "The( qualified)? import of ‘([^’]*)’ from module [^ ]* is redundant"
     , Just c <- contents
     , importLine <- textInRange _range c
     = [( "Remove " <> bindings <> " from import"

--- a/src/Development/IDE/LSP/CodeAction.hs
+++ b/src/Development/IDE/LSP/CodeAction.hs
@@ -321,12 +321,13 @@ dropBindingsFromImportLine bindings_ importLine =
         (_qualifier, T.uncons -> Just (_, unqualified)) -> unqualified
         _ -> x
 
-      importRest' =
-        T.intercalate ","
-          $ joinCloseParens
-          $ mapMaybe (filtering . T.strip)
-          $ T.splitOn ","
-          $ T.tail importRest
+      importRest' = case T.uncons importRest of
+        Just (_, x) ->
+          T.intercalate ","
+            $ joinCloseParens
+            $ mapMaybe (filtering . T.strip)
+            $ T.splitOn "," x
+        Nothing -> importRest
 
       filtering x = case () of
         () | x `elem` bindings -> Nothing

--- a/src/Development/IDE/LSP/CodeAction.hs
+++ b/src/Development/IDE/LSP/CodeAction.hs
@@ -311,12 +311,15 @@ dropBindingsFromImportLine :: [T.Text] -> T.Text -> T.Text
 dropBindingsFromImportLine bindings_ importLine =
       importPre <> "(" <> importRest'
     where
-      bindings = map
-        (\binding ->
-          if isAlpha (T.head binding) then binding else "(" <> binding <> ")"
-        )
-        bindings_
+      bindings = map (wrapOperatorInParens . removeQualified) bindings_
+
       (importPre, importRest) = T.breakOn "(" importLine
+
+      wrapOperatorInParens x = if isAlpha (T.head x) then x else "(" <> x <> ")"
+
+      removeQualified x = case T.breakOn "." x of
+        (_qualifier, T.uncons -> Just (_, unqualified)) -> unqualified
+        _ -> x
 
       importRest' =
         T.intercalate ","

--- a/src/Development/IDE/LSP/CodeAction.hs
+++ b/src/Development/IDE/LSP/CodeAction.hs
@@ -30,6 +30,8 @@ import Data.Char
 import Data.Maybe
 import Data.List.Extra
 import qualified Data.Text as T
+import Text.Regex.TDFA ((=~), (=~~))
+import Text.Regex.TDFA.Text()
 
 -- | Generate code actions.
 codeAction
@@ -85,14 +87,18 @@ executeAddSignatureCommand _lsp _ideState ExecuteCommandParams{..}
 
 suggestAction :: Maybe T.Text -> Diagnostic -> [(T.Text, [TextEdit])]
 suggestAction contents diag@Diagnostic{_range=_range@Range{..},..}
+--     The qualified import of ‘many’ from module ‘Control.Applicative’ is redundant
+    | Just [_, bindings] <- matchRegex _message ("The( qualified)? import of ‘([^’]*)’ from module [^ ]* is redundant")
+    , Just c <- contents
+    , importLine <- textInRange _range c
+    = [( "Remove " <> bindings <> " from import"
+       , [TextEdit _range (dropBindingsFromImportLine (T.splitOn "," bindings) importLine)])]
 
 -- File.hs:16:1: warning:
 --     The import of `Data.List' is redundant
 --       except perhaps to import instances from `Data.List'
 --     To import instances alone, use: import Data.List()
-    | "The import of " `T.isInfixOf` _message
-    || "The qualified import of " `T.isInfixOf` _message
-    , " is redundant" `T.isInfixOf` _message
+    | _message =~ ("The( qualified)? import of [^ ]* is redundant" :: String)
         = [("Remove import", [TextEdit (extendToWholeLineIfPossible contents _range) ""])]
 
 -- File.hs:52:41: error:
@@ -292,6 +298,47 @@ textInRange (Range (Position startRow startCol) (Position endRow endCol)) text =
       GT -> ""
     where
       linesBeginningWithStartLine = drop startRow (T.splitOn "\n" text)
+
+-- | Drop all occurrences of a binding in an import line.
+--   Preserves well-formedness but not whitespace between bindings.
+--
+-- >>> dropBindingsFromImportLine ["bA", "bC"] "import A(bA, bB,bC ,bA)"
+--  "import A(bB)"
+--
+-- >>> dropBindingsFromImportLine ["+"] "import "P" qualified A as B ((+))"
+--  "import "P" qualified A() as B hiding (bB)"
+dropBindingsFromImportLine :: [T.Text] -> T.Text -> T.Text
+dropBindingsFromImportLine bindings_ importLine =
+      importPre <> "(" <> importRest'
+    where
+      bindings = map
+        (\binding ->
+          if isAlpha (T.head binding) then binding else "(" <> binding <> ")"
+        )
+        bindings_
+      (importPre, importRest) = T.breakOn "(" importLine
+
+      importRest' =
+        T.intercalate ","
+          $ joinCloseParens
+          $ mapMaybe (filtering . T.strip)
+          $ T.splitOn ","
+          $ T.tail importRest
+
+      filtering x = case () of
+        () | x `elem` bindings -> Nothing
+        () | x `elem` (map (<> ")") bindings) -> Just ")"
+        _                      -> Just x
+
+      joinCloseParens (x : ")" : rest) = (x <> ")") : joinCloseParens rest
+      joinCloseParens (x       : rest) = x : joinCloseParens rest
+      joinCloseParens []               = []
+
+-- | Returns Just (the submatches) for the first capture, or Nothing.
+matchRegex :: T.Text -> T.Text -> Maybe [T.Text]
+matchRegex message regex = case message =~~ regex of
+  Just (_ :: T.Text, _ :: T.Text, _ :: T.Text, bindings) -> Just bindings
+  Nothing -> Nothing
 
 setHandlersCodeAction :: PartialHandlers
 setHandlersCodeAction = PartialHandlers $ \WithMessage{..} x -> return x{

--- a/stack-ghc-lib.yaml
+++ b/stack-ghc-lib.yaml
@@ -9,6 +9,8 @@ extra-deps:
 - ghc-lib-parser-8.8.1
 - ghc-lib-8.8.1
 - fuzzy-0.1.0.0
+- regex-base-0.94.0.0
+- regex-tdfa-1.3.1.0
 nix:
   packages: [zlib]
 flags:

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,5 +7,6 @@ extra-deps:
 - lsp-test-0.9.0.0
 - hie-bios-0.3.0
 - fuzzy-0.1.0.0
+- regex-tdfa-1.3.1.0
 nix:
   packages: [zlib]

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,6 +7,7 @@ extra-deps:
 - lsp-test-0.9.0.0
 - hie-bios-0.3.0
 - fuzzy-0.1.0.0
+- regex-base-0.94.0.0
 - regex-tdfa-1.3.1.0
 nix:
   packages: [zlib]

--- a/stack84.yaml
+++ b/stack84.yaml
@@ -12,6 +12,7 @@ extra-deps:
 - js-dgtable-0.5.2
 - hie-bios-0.3.0
 - fuzzy-0.1.0.0
+- regex-tdfa-1.3.1.0
 nix:
   packages: [zlib]
 allow-newer: true

--- a/stack84.yaml
+++ b/stack84.yaml
@@ -12,6 +12,7 @@ extra-deps:
 - js-dgtable-0.5.2
 - hie-bios-0.3.0
 - fuzzy-0.1.0.0
+- regex-base-0.94.0.0
 - regex-tdfa-1.3.1.0
 nix:
   packages: [zlib]

--- a/stack88.yaml
+++ b/stack88.yaml
@@ -7,6 +7,7 @@ extra-deps:
 - lsp-test-0.9.0.0
 - hie-bios-0.3.0
 - fuzzy-0.1.0.0
+- regex-tdfa-1.3.1.0
 allow-newer: true
 nix:
   packages: [zlib]

--- a/stack88.yaml
+++ b/stack88.yaml
@@ -7,6 +7,7 @@ extra-deps:
 - lsp-test-0.9.0.0
 - hie-bios-0.3.0
 - fuzzy-0.1.0.0
+- regex-base-0.94.0.0
 - regex-tdfa-1.3.1.0
 allow-newer: true
 nix:

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -640,7 +640,11 @@ removeImportTests = testGroup "remove import actions"
       _ <- waitForDiagnostics
       [CACodeAction action@CodeAction { _title = actionTitle }]
           <- getCodeActions docB (Range (Position 2 0) (Position 2 5))
+#if MIN_GHC_API_VERSION(8,6,0)
       liftIO $ "Remove !! from import" @=? actionTitle
+#else
+      liftIO $ "Remove A.!! from import" @=? actionTitle
+#endif
       executeCodeAction action
       contentAfterAction <- documentContents docB
       let expectedContentAfterAction = T.unlines


### PR DESCRIPTION
To parse and edit module imports I went with a very low tech solution, instead of reusing the GHC parse tree or similar, in the interest of preserving as much of the user text as possible.

To match on the GHC error output I went with *regex-tdfa*, which is able to run regular expressions on `Text` values, because it seems the right tool for the job. While it has an upper bound on `base` that rules out 8.8, it worked for me with `allow-newer`. 