### PR TITLE
Speed up span lookups

### DIFF
--- a/src/Development/IDE/Spans/AtPoint.hs
+++ b/src/Development/IDE/Spans/AtPoint.hs
@@ -142,12 +142,16 @@ spansAtPoint :: Position -> [SpanInfo] -> [SpanInfo]
 spansAtPoint pos = filter atp where
   line = _line pos
   cha = _character pos
-  atp SpanInfo{..} =    spaninfoStartLine <= line
-                     && spaninfoEndLine >= line
-                     && spaninfoStartCol <= cha
-                     -- The end col points to the column after the
-                     -- last character so we use > instead of >=
-                     && spaninfoEndCol > cha
+  atp SpanInfo{..} =
+      startsBeforePosition && endsAfterPosition
+    where
+      startLineCmp = compare spaninfoStartLine line
+      endLineCmp   = compare spaninfoEndLine   line
+
+      startsBeforePosition = startLineCmp == LT || (startLineCmp == EQ && spaninfoStartCol <= cha)
+                                              -- The end col points to the column after the
+                                              -- last character so we use > instead of >=
+      endsAfterPosition = endLineCmp == GT || (endLineCmp == EQ && spaninfoEndCol > cha)
 
 showName :: Outputable a => a -> T.Text
 showName = T.pack . prettyprint

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -953,7 +953,7 @@ findDefinitionAndHoverTests = let
   , test broken broken fffL8  fff    "field in record construction     #71"
   , test yes    yes    fffL14 fff    "field name used as accessor"          -- 120 in Calculate.hs
   , test yes    yes    aaaL14 aaa    "top-level name"                       -- 120
-  , test broken broken dcL7   tcDC   "data constructor record         #247"
+  , test yes    yes    dcL7   tcDC   "data constructor record         #247"
   , test yes    yes    dcL12  tcDC   "data constructor plain"               -- 121
   , test yes    yes    tcL6   tcData "type constructor                #248" -- 147
   , test broken yes    xtcL5  xtc    "type constructor external   #248,249"


### PR DESCRIPTION
Following the first part of the discussion in #101, 
and reusing some code from https://github.com/mpickering/ghcide/commits/wip/type-map.

An interval tree is used to speed up span lookups, which benefits hovers and
definition lookups. The computation of spans is still done using the same
algorithm as previously.

Fixes #247 by sorting matching spans by relevance.