### PR TITLE
Document symbols provider

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -129,6 +129,7 @@ library
         Development.IDE.LSP.Completions
         Development.IDE.LSP.HoverDefinition
         Development.IDE.LSP.Notifications
+        Development.IDE.LSP.Outline
         Development.IDE.Spans.AtPoint
         Development.IDE.Spans.Calculate
         Development.IDE.Spans.Documentation

--- a/src/Development/IDE/Core/Preprocessor.hs
+++ b/src/Development/IDE/Core/Preprocessor.hs
@@ -8,7 +8,6 @@ module Development.IDE.Core.Preprocessor
 import Development.IDE.GHC.CPP
 import Development.IDE.GHC.Orphans()
 import Development.IDE.GHC.Compat
-import GHC
 import GhcMonad
 import StringBuffer as SB
 

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -56,7 +56,7 @@ import Development.IDE.Core.RuleTypes
 
 import           GHC hiding (parseModule, typecheckModule)
 import qualified GHC.LanguageExtensions as LangExt
-import Development.IDE.GHC.Compat
+import Development.IDE.GHC.Compat (hie_file_result, readHieFile)
 import           UniqSupply
 import NameCache
 import HscTypes

--- a/src/Development/IDE/GHC/Compat.hs
+++ b/src/Development/IDE/GHC/Compat.hs
@@ -2,6 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE PatternSynonyms #-}
 #include "ghc-api-version.h"
 
 -- | Attempt at hiding the GHC version differences we can.
@@ -15,7 +16,14 @@ module Development.IDE.GHC.Compat(
     includePathsGlobal,
     includePathsQuote,
     addIncludePathsQuote,
-    ghcEnumerateExtensions
+    ghcEnumerateExtensions,
+    pattern DerivD,
+    pattern ForD,
+    pattern InstD,
+    pattern TyClD,
+    pattern ValD,
+    pattern ClassOpSig,
+    module GHC
     ) where
 
 import StringBuffer
@@ -26,12 +34,14 @@ import GHC.LanguageExtensions.Type
 import Data.List.Extra (enumerate)
 #endif
 
+import qualified GHC
+import GHC hiding (ClassOpSig, DerivD, ForD, InstD, TyClD, ValD)
+
 #if MIN_GHC_API_VERSION(8,8,0)
 import HieAst
 import HieBin
 import HieTypes
 #else
-import GHC
 import GhcPlugins
 import NameCache
 import Avail
@@ -82,4 +92,52 @@ ghcEnumerateExtensions = enumerate
 ghcEnumerateExtensions = [Cpp .. StarIsType]
 #else
 ghcEnumerateExtensions = [Cpp .. EmptyDataDeriving]
+#endif
+
+pattern DerivD :: DerivDecl p -> HsDecl p
+pattern DerivD x <-
+#if MIN_GHC_API_VERSION(8,6,0)
+    GHC.DerivD _ x
+#else
+    GHC.DerivD x
+#endif
+
+pattern ForD :: ForeignDecl p -> HsDecl p
+pattern ForD x <-
+#if MIN_GHC_API_VERSION(8,6,0)
+    GHC.ForD _ x
+#else
+    GHC.ForD x
+#endif
+
+pattern ValD :: HsBind p -> HsDecl p
+pattern ValD x <-
+#if MIN_GHC_API_VERSION(8,6,0)
+    GHC.ValD _ x
+#else
+    GHC.ValD x
+#endif
+
+pattern InstD :: InstDecl p -> HsDecl p
+pattern InstD x <-
+#if MIN_GHC_API_VERSION(8,6,0)
+    GHC.InstD _ x
+#else
+    GHC.InstD x
+#endif
+
+pattern TyClD :: TyClDecl p -> HsDecl p
+pattern TyClD x <-
+#if MIN_GHC_API_VERSION(8,6,0)
+    GHC.TyClD _ x
+#else
+    GHC.TyClD x
+#endif
+
+pattern ClassOpSig :: Bool -> [Located (IdP pass)] -> LHsSigType pass -> Sig pass
+pattern ClassOpSig a b c <-
+#if MIN_GHC_API_VERSION(8,6,0)
+    GHC.ClassOpSig _ a b c
+#else
+    GHC.ClassOpSig a b c
 #endif

--- a/src/Development/IDE/GHC/Error.hs
+++ b/src/Development/IDE/GHC/Error.hs
@@ -12,6 +12,7 @@ module Development.IDE.GHC.Error
 
   -- * utilities working with spans
   , srcSpanToLocation
+  , srcSpanToRange
   , srcSpanToFilename
   , zeroSpan
   , realSpan

--- a/src/Development/IDE/LSP/LanguageServer.hs
+++ b/src/Development/IDE/LSP/LanguageServer.hs
@@ -32,6 +32,7 @@ import Development.IDE.LSP.HoverDefinition
 import Development.IDE.LSP.CodeAction
 import Development.IDE.LSP.Completions
 import Development.IDE.LSP.Notifications
+import Development.IDE.LSP.Outline
 import Development.IDE.Core.Service
 import Development.IDE.Types.Logger
 import Development.IDE.Core.FileStore
@@ -99,6 +100,7 @@ runLanguageServer options userHandlers getIdeState = do
             setHandlersDefinition <> setHandlersHover <>
             setHandlersCodeAction <> setHandlersCodeLens <> -- useful features someone may override
             setHandlersCompletion <>
+            setHandlersOutline <>
             userHandlers <>
             setHandlersNotifications <> -- absolutely critical, join them with user notifications
             cancelHandler cancelRequest

--- a/src/Development/IDE/LSP/Outline.hs
+++ b/src/Development/IDE/LSP/Outline.hs
@@ -1,0 +1,185 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+module Development.IDE.LSP.Outline
+  ( setHandlersOutline
+  )
+where
+
+import qualified Language.Haskell.LSP.Core     as LSP
+import           Language.Haskell.LSP.Messages
+import           Language.Haskell.LSP.Types
+import           Data.Functor
+import           Data.Generics
+import           Data.Maybe
+import           Data.Text                      ( Text
+                                                , pack
+                                                )
+import qualified Data.Text                     as T
+import           Development.IDE.Core.Rules
+import           Development.IDE.Core.Shake
+import           Development.IDE.GHC.Error      ( srcSpanToRange )
+import           Development.IDE.LSP.Server
+import           Development.IDE.Types.Location
+import           GHC
+import           Outputable                     ( Outputable
+                                                , ppr
+                                                , showSDocUnsafe
+                                                )
+
+setHandlersOutline :: PartialHandlers
+setHandlersOutline = PartialHandlers $ \WithMessage {..} x -> return x
+  { LSP.documentSymbolHandler = withResponse RspDocumentSymbols moduleOutline
+  }
+
+moduleOutline
+  :: LSP.LspFuncs () -> IdeState -> DocumentSymbolParams -> IO DSResult
+moduleOutline _lsp ideState DocumentSymbolParams { _textDocument = TextDocumentIdentifier uri }
+  = case uriToFilePath uri of
+    Just (toNormalizedFilePath -> fp) -> do
+      mb_decls <- runAction ideState $ use GetParsedModule fp
+      pure $ case mb_decls of
+        Nothing -> DSDocumentSymbols (List [])
+        Just (ParsedModule { pm_parsed_source = L _ltop HsModule { hsmodName, hsmodDecls, hsmodImports } })
+          -> let
+               declSymbols  = mapMaybe documentSymbolForDecl hsmodDecls
+               moduleSymbol = hsmodName <&> \(L l m) ->
+                 (defDocumentSymbol l :: DocumentSymbol)
+                   { _name  = pprText m
+                   , _kind  = SkFile
+                   , _range = Range (Position 0 0) (Position 10000000 0) -- _ltop is 0 0 0 0
+                   }
+               importSymbols = mapMaybe documentSymbolForImport hsmodImports
+               allSymbols    = case moduleSymbol of
+                 Nothing -> importSymbols <> declSymbols
+                 Just x ->
+                   [ x { _children = Just (List (importSymbols <> declSymbols))
+                       }
+                   ]
+             in
+               DSDocumentSymbols (List allSymbols)
+
+
+    Nothing -> pure $ DSDocumentSymbols (List [])
+
+documentSymbolForDecl :: Located (HsDecl GhcPs) -> Maybe DocumentSymbol
+documentSymbolForDecl (L l (TyClD _ FamDecl { tcdFam = FamilyDecl { fdLName = L _ n, fdInfo, fdTyVars } }))
+  = Just (defDocumentSymbol l :: DocumentSymbol)
+    { _name   = showRdrName n
+                  <> (case pprText fdTyVars of
+                       "" -> ""
+                       t  -> " " <> t
+                     )
+    , _detail = Just $ pprText fdInfo
+    , _kind   = SkClass
+    }
+documentSymbolForDecl (L l (TyClD _ ClassDecl { tcdLName = L _ name, tcdSigs, tcdTyVars }))
+  = Just (defDocumentSymbol l :: DocumentSymbol)
+    { _name     = showRdrName name
+                    <> (case pprText tcdTyVars of
+                         "" -> ""
+                         t  -> " " <> t
+                       )
+    , _kind     = SkClass
+    , _detail   = Just "class"
+    , _children =
+      Just $ List
+        [ (defDocumentSymbol l :: DocumentSymbol)
+            { _name           = showRdrName n
+            , _kind           = SkMethod
+            , _selectionRange = srcSpanToRange l'
+            }
+        | L l  (ClassOpSig _ False names _) <- tcdSigs
+        , L l' n                            <- names
+        ]
+    }
+documentSymbolForDecl (L l (TyClD _ DataDecl { tcdLName = L _ name, tcdDataDefn = HsDataDefn { dd_cons } }))
+  = Just (defDocumentSymbol l :: DocumentSymbol)
+    { _name     = showRdrName name
+    , _kind     = SkStruct
+    , _children =
+      Just $ List
+        [ (defDocumentSymbol l :: DocumentSymbol)
+            { _name           = showRdrName n
+            , _kind           = SkConstructor
+            , _selectionRange = srcSpanToRange l'
+            }
+        | L l  x <- dd_cons
+        , L l' n <- getConNames x
+        ]
+    }
+documentSymbolForDecl (L l (TyClD _ SynDecl { tcdLName = L l' n })) = Just
+  (defDocumentSymbol l :: DocumentSymbol) { _name           = showRdrName n
+                                          , _kind           = SkTypeParameter
+                                          , _selectionRange = srcSpanToRange l'
+                                          }
+documentSymbolForDecl (L l (InstD _ (ClsInstD { cid_inst = ClsInstDecl { cid_poly_ty } })))
+  = Just (defDocumentSymbol l :: DocumentSymbol) { _name = pprText cid_poly_ty
+                                                 , _kind = SkInterface
+                                                 }
+documentSymbolForDecl (L l (InstD _ DataFamInstD { dfid_inst = DataFamInstDecl (HsIB { hsib_body = FamEqn { feqn_tycon, feqn_pats } }) }))
+  = Just (defDocumentSymbol l :: DocumentSymbol)
+    { _name = showRdrName (unLoc feqn_tycon) <> " " <> T.unwords
+                (map pprText feqn_pats)
+    , _kind = SkInterface
+    }
+documentSymbolForDecl (L l (InstD _ TyFamInstD { tfid_inst = TyFamInstDecl (HsIB { hsib_body = FamEqn { feqn_tycon, feqn_pats } }) }))
+  = Just (defDocumentSymbol l :: DocumentSymbol)
+    { _name = showRdrName (unLoc feqn_tycon) <> " " <> T.unwords
+                (map pprText feqn_pats)
+    , _kind = SkInterface
+    }
+documentSymbolForDecl (L l (DerivD _ DerivDecl { deriv_type })) =
+  gfindtype deriv_type <&> \(L (_ :: SrcSpan) name) ->
+    (defDocumentSymbol l :: DocumentSymbol) { _name = pprText @(HsType GhcPs)
+                                              name
+                                            , _kind = SkInterface
+                                            }
+documentSymbolForDecl (L l (ValD _ x)) =
+  gfindtype x <&> \(L (_ :: SrcSpan) name) ->
+    (defDocumentSymbol l :: DocumentSymbol)
+      { _name   = showRdrName name
+      , _kind   = case x of
+                    PatBind{} -> SkConstant
+                    _         -> SkFunction
+      , _detail = Nothing  -- avoid UI issues with multi-line detail
+      }
+
+documentSymbolForDecl (L l (ForD _ x)) = Just
+  (defDocumentSymbol l :: DocumentSymbol)
+    { _name   = case x of
+                  ForeignImport{} -> name
+                  ForeignExport{} -> name
+                  _               -> "?"
+    , _kind   = SkObject
+    , _detail = case x of
+                  ForeignImport{} -> Just "import"
+                  ForeignExport{} -> Just "export"
+                  _               -> Nothing
+    }
+  where name = showRdrName $ unLoc $ fd_name x
+
+documentSymbolForDecl _ = Nothing
+
+documentSymbolForImport :: Located (ImportDecl GhcPs) -> Maybe DocumentSymbol
+documentSymbolForImport (L l ImportDecl { ideclName, ideclQualified }) = Just
+  (defDocumentSymbol l :: DocumentSymbol)
+    { _name   = "import " <> pprText ideclName
+    , _kind   = SkModule
+    , _detail = if ideclQualified then Just "qualified" else Nothing
+    }
+documentSymbolForImport _ = Nothing
+
+defDocumentSymbol :: SrcSpan -> DocumentSymbol
+defDocumentSymbol l = DocumentSymbol { .. } where
+  _detail         = Nothing
+  _deprecated     = Nothing
+  _name           = ""
+  _kind           = SkUnknown 0
+  _range          = srcSpanToRange l
+  _selectionRange = srcSpanToRange l
+  _children       = Nothing
+
+showRdrName :: RdrName -> Text
+showRdrName = pprText
+
+pprText :: Outputable a => a -> Text
+pprText = pack . showSDocUnsafe . ppr

--- a/src/Development/IDE/LSP/Outline.hs
+++ b/src/Development/IDE/LSP/Outline.hs
@@ -140,9 +140,7 @@ documentSymbolForDecl (L l (ValD x)) =
   gfindtype x <&> \(L (_ :: SrcSpan) name) ->
     (defDocumentSymbol l :: DocumentSymbol)
       { _name   = showRdrName name
-      , _kind   = case x of
-                    PatBind{} -> SkConstant
-                    _         -> SkFunction
+      , _kind   = SkFunction
       , _detail = Nothing  -- avoid UI issues with multi-line detail
       }
 

--- a/src/Development/IDE/LSP/Outline.hs
+++ b/src/Development/IDE/LSP/Outline.hs
@@ -48,7 +48,7 @@ moduleOutline _lsp ideState DocumentSymbolParams { _textDocument = TextDocumentI
                  (defDocumentSymbol l :: DocumentSymbol)
                    { _name  = pprText m
                    , _kind  = SkFile
-                   , _range = Range (Position 0 0) (Position 10000000 0) -- _ltop is 0 0 0 0
+                   , _range = Range (Position 0 0) (Position maxBound 0) -- _ltop is 0 0 0 0
                    }
                importSymbols = mapMaybe documentSymbolForImport hsmodImports
                allSymbols    = case moduleSymbol of

--- a/src/Development/IDE/LSP/Outline.hs
+++ b/src/Development/IDE/LSP/Outline.hs
@@ -136,12 +136,15 @@ documentSymbolForDecl (L l (DerivD DerivDecl { deriv_type })) =
                                               name
                                             , _kind = SkInterface
                                             }
-documentSymbolForDecl (L l (ValD x)) =
-  gfindtype x <&> \(L (_ :: SrcSpan) name) ->
+documentSymbolForDecl (L l (ValD FunBind{fun_id = L _ name})) = Just
     (defDocumentSymbol l :: DocumentSymbol)
       { _name   = showRdrName name
       , _kind   = SkFunction
-      , _detail = Nothing  -- avoid UI issues with multi-line detail
+      }
+documentSymbolForDecl (L l (ValD PatBind{pat_lhs})) = Just
+    (defDocumentSymbol l :: DocumentSymbol)
+      { _name   = pprText pat_lhs
+      , _kind   = SkFunction
       }
 
 documentSymbolForDecl (L l (ForD x)) = Just

--- a/src/Development/IDE/Spans/AtPoint.hs
+++ b/src/Development/IDE/Spans/AtPoint.hs
@@ -22,7 +22,6 @@ import           Development.IDE.Spans.Type as SpanInfo
 
 -- GHC API imports
 import Avail
-import GHC
 import DynFlags
 import FastString
 import Name

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2,6 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE CPP #-}
 #include "ghc-api-version.h"
 
@@ -42,6 +43,7 @@ main = defaultMain $ testGroup "HIE"
   , diagnosticTests
   , codeActionTests
   , codeLensesTests
+  , outlineTests
   , findDefinitionAndHoverTests
   , pluginTests
   , preprocessorTests
@@ -68,7 +70,7 @@ initializeResponseTests = withResource acquire release tests where
     , chk "NO goto implementation"  _implementationProvider (Just $ GotoOptionsStatic False)
     , chk "NO find references"          _referencesProvider  Nothing
     , chk "NO doc highlight"     _documentHighlightProvider  Nothing
-    , chk "NO doc symbol"           _documentSymbolProvider  Nothing
+    , chk "   doc symbol"           _documentSymbolProvider  (Just True)
     , chk "NO workspace symbol"    _workspaceSymbolProvider  Nothing
     , chk "   code action"             _codeActionProvider $ Just $ CodeActionOptionsStatic True
     , chk "   code lens"                 _codeLensProvider $ Just $ CodeLensOptions Nothing
@@ -1006,6 +1008,141 @@ completionTests
       , _command = Nothing
       , _xdata = Just (Aeson.toJSON (xdata :: [T.Text]))
       }
+
+outlineTests :: TestTree
+outlineTests = testGroup
+  "outline"
+  [ testSessionWait "type class" $ do
+    let source = T.unlines ["module A where", "class A a where a :: a -> Bool"]
+    docId   <- openDoc' "A.hs" "haskell" source
+    symbols <- getDocumentSymbols docId
+    liftIO $ symbols @?= Left
+      [ moduleSymbol
+          "A"
+          (R 0 7 0 8)
+          [ classSymbol "A a"
+                        (R 1 0 1 30)
+                        [docSymbol' "a" SkMethod (R 1 16 1 30) (R 1 16 1 17)]
+          ]
+      ]
+  , testSessionWait "type class instance " $ do
+    let source = T.unlines ["class A a where", "instance A () where"]
+    docId   <- openDoc' "A.hs" "haskell" source
+    symbols <- getDocumentSymbols docId
+    liftIO $ symbols @?= Left
+      [ classSymbol "A a" (R 0 0 0 15) []
+      , docSymbol "A ()" SkInterface (R 1 0 1 19)
+      ]
+  , testSessionWait "type family" $ do
+    let source = T.unlines ["{-# language TypeFamilies #-}", "type family A"]
+    docId   <- openDoc' "A.hs" "haskell" source
+    symbols <- getDocumentSymbols docId
+    liftIO $ symbols @?= Left [docSymbolD "A" "type family" SkClass (R 1 0 1 13)]
+  , testSessionWait "type family instance " $ do
+    let source = T.unlines
+          [ "{-# language TypeFamilies #-}"
+          , "type family A a"
+          , "type instance A () = ()"
+          ]
+    docId   <- openDoc' "A.hs" "haskell" source
+    symbols <- getDocumentSymbols docId
+    liftIO $ symbols @?= Left
+      [ docSymbolD "A a"   "type family" SkClass     (R 1 0 1 15)
+      , docSymbol "A ()" SkInterface (R 2 0 2 23)
+      ]
+  , testSessionWait "data family" $ do
+    let source = T.unlines ["{-# language TypeFamilies #-}", "data family A"]
+    docId   <- openDoc' "A.hs" "haskell" source
+    symbols <- getDocumentSymbols docId
+    liftIO $ symbols @?= Left [docSymbolD "A" "data family" SkClass (R 1 0 1 11)]
+  , testSessionWait "data family instance " $ do
+    let source = T.unlines
+          [ "{-# language TypeFamilies #-}"
+          , "data family A a"
+          , "data instance A () = A ()"
+          ]
+    docId   <- openDoc' "A.hs" "haskell" source
+    symbols <- getDocumentSymbols docId
+    liftIO $ symbols @?= Left
+      [ docSymbolD "A a"   "data family" SkClass     (R 1 0 1 11)
+      , docSymbol "A ()" SkInterface (R 2 0 2 25)
+      ]
+  , testSessionWait "constant" $ do
+    let source = T.unlines ["a = ()"]
+    docId   <- openDoc' "A.hs" "haskell" source
+    symbols <- getDocumentSymbols docId
+    liftIO $ symbols @?= Left
+      [docSymbol "a" SkFunction (R 0 0 0 6)]
+  , testSessionWait "function" $ do
+    let source = T.unlines ["a x = ()"]
+    docId   <- openDoc' "A.hs" "haskell" source
+    symbols <- getDocumentSymbols docId
+    liftIO $ symbols @?= Left [docSymbol "a" SkFunction (R 0 0 0 8)]
+  , testSessionWait "type synonym" $ do
+    let source = T.unlines ["type A = Bool"]
+    docId   <- openDoc' "A.hs" "haskell" source
+    symbols <- getDocumentSymbols docId
+    liftIO $ symbols @?= Left
+      [docSymbol' "A" SkTypeParameter (R 0 0 0 13) (R 0 5 0 6)]
+  , testSessionWait "datatype" $ do
+    let source = T.unlines ["data A = C"]
+    docId   <- openDoc' "A.hs" "haskell" source
+    symbols <- getDocumentSymbols docId
+    liftIO $ symbols @?= Left
+      [ docSymbolWithChildren "A"
+                              SkStruct
+                              (R 0 0 0 10)
+                              [docSymbol "C" SkConstructor (R 0 9 0 10)]
+      ]
+  , testSessionWait " import" $ do
+    let source = T.unlines ["import Data.Maybe"]
+    docId   <- openDoc' "A.hs" "haskell" source
+    symbols <- getDocumentSymbols docId
+    liftIO $ symbols @?= Left
+      [docSymbol "import Data.Maybe" SkModule (R 0 0 0 17)]
+  , testSessionWait "foreign import" $ do
+    let source = T.unlines
+          [ "{-# language ForeignFunctionInterface #-}"
+          , "foreign import ccall \"a\" a :: Int"
+          ]
+    docId   <- openDoc' "A.hs" "haskell" source
+    symbols <- getDocumentSymbols docId
+    liftIO $ symbols @?= Left [docSymbolD "a" "import" SkObject (R 1 0 1 33)]
+  , testSessionWait "foreign export" $ do
+    let source = T.unlines
+          [ "{-# language ForeignFunctionInterface #-}"
+          , "foreign export ccall odd :: Int -> Bool"
+          ]
+    docId   <- openDoc' "A.hs" "haskell" source
+    symbols <- getDocumentSymbols docId
+    liftIO $ symbols @?= Left [docSymbolD "odd" "export" SkObject (R 1 0 1 39)]
+  ]
+ where
+  docSymbol name kind loc =
+    DocumentSymbol name Nothing kind Nothing loc loc Nothing
+  docSymbol' name kind loc selectionLoc =
+    DocumentSymbol name Nothing kind Nothing loc selectionLoc Nothing
+  docSymbolD name detail kind loc =
+    DocumentSymbol name (Just detail) kind Nothing loc loc Nothing
+  docSymbolWithChildren name kind loc cc =
+    DocumentSymbol name Nothing kind Nothing loc loc (Just $ List cc)
+  moduleSymbol name loc cc = DocumentSymbol name
+                                            Nothing
+                                            SkFile
+                                            Nothing
+                                            (R 0 0 10000000 0)
+                                            loc
+                                            (Just $ List cc)
+  classSymbol name loc cc = DocumentSymbol name
+                                           (Just "class")
+                                           SkClass
+                                           Nothing
+                                           loc
+                                           loc
+                                           (Just $ List cc)
+
+pattern R :: Int -> Int -> Int -> Int -> Range
+pattern R x y x' y' = Range (Position x y) (Position x' y')
 
 xfail :: TestTree -> String -> TestTree
 xfail = flip expectFailBecause

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -1073,6 +1073,18 @@ outlineTests = testGroup
     symbols <- getDocumentSymbols docId
     liftIO $ symbols @?= Left
       [docSymbol "a" SkFunction (R 0 0 0 6)]
+  , testSessionWait "pattern" $ do
+    let source = T.unlines ["Just foo = Just 21"]
+    docId   <- openDoc' "A.hs" "haskell" source
+    symbols <- getDocumentSymbols docId
+    liftIO $ symbols @?= Left
+      [docSymbol "Just foo" SkFunction (R 0 0 0 18)]
+  , testSessionWait "pattern with type signature" $ do
+    let source = T.unlines ["{-# language ScopedTypeVariables #-}", "a :: () = ()"]
+    docId   <- openDoc' "A.hs" "haskell" source
+    symbols <- getDocumentSymbols docId
+    liftIO $ symbols @?= Left
+      [docSymbol "a :: ()" SkFunction (R 1 0 1 12)]
   , testSessionWait "function" $ do
     let source = T.unlines ["a x = ()"]
     docId   <- openDoc' "A.hs" "haskell" source
@@ -1094,7 +1106,7 @@ outlineTests = testGroup
                               (R 0 0 0 10)
                               [docSymbol "C" SkConstructor (R 0 9 0 10)]
       ]
-  , testSessionWait " import" $ do
+  , testSessionWait "import" $ do
     let source = T.unlines ["import Data.Maybe"]
     docId   <- openDoc' "A.hs" "haskell" source
     symbols <- getDocumentSymbols docId

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -1130,7 +1130,7 @@ outlineTests = testGroup
                                             Nothing
                                             SkFile
                                             Nothing
-                                            (R 0 0 10000000 0)
+                                            (R 0 0 maxBound 0)
                                             loc
                                             (Just $ List cc)
   classSymbol name loc cc = DocumentSymbol name


### PR DESCRIPTION
Low hanging fruit, worth doing as VS Code makes document outlines actually useful by adorning them with warnings and errors markers.