### PR TITLE
Fix check for empty file path

### DIFF
--- a/src/Development/IDE/Types/Location.hs
+++ b/src/Development/IDE/Types/Location.hs
@@ -66,8 +66,11 @@ fromNormalizedFilePath (NormalizedFilePath fp) = fp
 -- So we have our own wrapper here that supports empty filepaths.
 uriToFilePath' :: Uri -> Maybe FilePath
 uriToFilePath' uri
-    | uri == filePathToUri "" = Just ""
+    | uri == fromNormalizedUri emptyPathUri = Just ""
     | otherwise = LSP.uriToFilePath uri
+
+emptyPathUri :: NormalizedUri
+emptyPathUri = filePathToUri' ""
 
 filePathToUri' :: NormalizedFilePath -> NormalizedUri
 filePathToUri' (NormalizedFilePath fp) = toNormalizedUri $ Uri $ T.pack $ LSP.fileScheme <> "//" <> platformAdjustToUriPath fp

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -18,6 +18,7 @@ import Development.IDE.GHC.Util
 import qualified Data.Text as T
 import Development.IDE.Test
 import Development.IDE.Test.Runfiles
+import Development.IDE.Types.Location
 import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
 import Language.Haskell.LSP.Types.Capabilities
@@ -48,6 +49,7 @@ main = defaultMain $ testGroup "HIE"
   , pluginTests
   , preprocessorTests
   , thTests
+  , unitTests
   ]
 
 initializeResponseTests :: TestTree
@@ -1306,3 +1308,10 @@ openTestDataDoc :: FilePath -> Session TextDocumentIdentifier
 openTestDataDoc path = do
   source <- liftIO $ readFileUtf8 $ "test/data" </> path
   openDoc' path "haskell" source
+
+unitTests :: TestTree
+unitTests = do
+  testGroup "Unit"
+     [ testCase "empty file path" $
+         uriToFilePath' (fromNormalizedUri $ filePathToUri' "") @?= Just ""
+     ]


### PR DESCRIPTION
I accidentally broke this on Windows in #303 by letting the two
conversirons get out of sync.