### PR TITLE
Remove JSON instances for unused completion code

### DIFF
--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -1096,7 +1096,7 @@ completionTests
       , _additionalTextEdits = Nothing
       , _commitCharacters = Nothing
       , _command = Nothing
-      , _xdata = Just (Aeson.toJSON (xdata :: [T.Text]))
+      , _xdata = Nothing
       }
 
 outlineTests :: TestTree

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -11,7 +11,6 @@ module Main (main) where
 import Control.Applicative.Combinators
 import Control.Monad
 import Control.Monad.IO.Class (liftIO)
-import qualified Data.Aeson as Aeson
 import Data.Char (toLower)
 import Data.Foldable
 import Development.IDE.GHC.Util
@@ -1061,7 +1060,7 @@ completionTests
         let source = T.unlines ["module A where", "f = hea"]
         docId <- openDoc' "A.hs" "haskell" source
         compls <- getCompletions docId (Position 1 7)
-        liftIO $ compls @?= [complItem "head" ["GHC.List", "base", "v", "head"] (Just CiFunction)]
+        liftIO $ compls @?= [complItem "head" (Just CiFunction)]
     , testSessionWait "type" $ do
         let source = T.unlines ["{-# OPTIONS_GHC -Wall #-}", "module A () where", "f :: ()", "f = ()"]
         docId <- openDoc' "A.hs" "haskell" source
@@ -1069,8 +1068,8 @@ completionTests
         changeDoc docId [TextDocumentContentChangeEvent Nothing Nothing $ T.unlines ["{-# OPTIONS_GHC -Wall #-}", "module A () where", "f :: Bo", "f = True"]]
         compls <- getCompletions docId (Position 2 7)
         liftIO $ compls @?=
-            [ complItem "Bounded" ["GHC.Enum", "base", "t", "Bounded"] (Just CiClass)
-            , complItem "Bool" ["GHC.Types", "ghc-prim", "t", "Bool"] (Just CiClass)
+            [ complItem "Bounded" (Just CiClass)
+            , complItem "Bool" (Just CiClass)
             ]
     , testSessionWait "qualified" $ do
         let source = T.unlines ["{-# OPTIONS_GHC -Wunused-binds #-}", "module A () where", "f = ()"]
@@ -1078,10 +1077,10 @@ completionTests
         expectDiagnostics [ ("A.hs", [(DsWarning, (2, 0), "not used")]) ]
         changeDoc docId [TextDocumentContentChangeEvent Nothing Nothing $ T.unlines ["{-# OPTIONS_GHC -Wunused-binds #-}", "module A () where", "f = Prelude.hea"]]
         compls <- getCompletions docId (Position 2 15)
-        liftIO $ compls @?= [complItem "head" ["GHC.List", "base", "v", "head"] (Just CiFunction)]
+        liftIO $ compls @?= [complItem "head" (Just CiFunction)]
     ]
   where
-    complItem label xdata kind = CompletionItem
+    complItem label kind = CompletionItem
       { _label = label
       , _kind = kind
       , _detail = Just "Prelude"


### PR DESCRIPTION
**Note:** this PR is one half of the one originally in #288

According to #227 (comment), such instances are only required for implementing the "resolve completion" functionality in LSP. However, at this moment all the information is returned directly in the completion request, so there's no need for that. This PR removes the code, and also updates the tests.