### PR TITLE
Extend version message to include path and git commit

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -162,6 +162,7 @@ executable ghcide
         filepath,
         ghc-paths,
         ghc,
+        gitrev,
         haskell-lsp,
         hie-bios >= 0.3.2 && < 0.4,
         ghcide,


### PR DESCRIPTION
Path is useful for diagnosing issues, e.g. a global ghcide being picked up instead of a project one in Nix. 
```
[nix-shell:~/scratch/ghcide]$ ghcide --version
ghcide version: 0.0.5 (GHC: 8.8.1) (PATH: /nix/store/vwdng7227zjsfhzy6c6hcssmbk7yfyki-ghcide-0.0.5/bin/ghcide)
```
Git commit is useful when developing, to make sure tests are running on the expected binary
```
[nix-shell:~/scratch/ghcide]$ cabal run ghcide -- --version
Up to date
ghcide version: 0.0.5 (GHC: 8.8.1) (PATH: /home/pepe/scratch/ghcide/dist-newstyle/build/x86_64-linux/ghc-8.8.1/ghcide-0.0.5/x/ghcide/build/ghcide/ghcide) (GIT hash: 20406624e73263b9f337c3187a5badca88c9cc63)
```