### PR TITLE
Add a new flag --shake-profiling DIR

### DIFF
--- a/exe/Arguments.hs
+++ b/exe/Arguments.hs
@@ -11,6 +11,7 @@ data Arguments = Arguments
     ,argsCwd :: Maybe FilePath
     ,argFiles :: [FilePath]
     ,argsVersion :: Bool
+    ,argsShakeProfiling :: Maybe FilePath
     }
 
 getArguments :: IO Arguments
@@ -27,3 +28,4 @@ arguments = Arguments
       <*> optional (strOption $ long "cwd" <> metavar "DIR" <> help "Change to this directory")
       <*> many (argument str (metavar "FILES/DIRS..."))
       <*> switch (long "version" <> help "Show ghcide and GHC versions")
+      <*> optional (strOption $ long "shake-profiling" <> metavar "DIR" <> help "Dump profiling reports to this directory")

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -93,7 +93,9 @@ main = do
             -- very important we only call loadSession once, and it's fast, so just do it before starting
             session <- loadSession dir
             let options = (defaultIdeOptions $ return session)
-                    { optReportProgress = clientSupportsProgress caps }
+                    { optReportProgress = clientSupportsProgress caps 
+                    , optShakeProfiling = argsShakeProfiling
+                    }
             initialise (mainRule >> action kick) getLspId event (logger minBound) options vfs
     else do
         putStrLn $ "Ghcide setup tester in " ++ dir ++ "."


### PR DESCRIPTION
The flag provides a way to enable Shake profiling reports without recompiling.
Debug output prints links to the profiling artifacts for convenience.