### PR TITLE
Tests for issue 310 (misleading hover on inner signature)

### DIFF
--- a/test/data/GotoHover.hs
+++ b/test/data/GotoHover.hs
@@ -42,3 +42,9 @@ documented :: Monad m => Either Int (m a)
 documented = Left 7518
 
 listOfInt = [ 8391 :: Int, 6268 ]
+
+outer :: Bool
+outer = undefined where
+
+  inner :: Char
+  inner = undefined

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -1097,9 +1097,9 @@ findDefinitionAndHoverTests = let
   chrL36 = Position 36 25  ;  litC   = [ExpectHoverText ["'t'"]]
   txtL8  = Position  8 14  ;  litT   = [ExpectHoverText ["\"dfgv\""]]
   lstL43 = Position 43 12  ;  litL   = [ExpectHoverText ["[ 8391 :: Int, 6268 ]"]]
-  outL45 = Position 45  3  ;  outSig = [ExpectHoverText ["outer", "Bool"], mkR 45 0 45 5]
+  outL45 = Position 45  3  ;  outSig = [ExpectHoverText ["outer", "Bool"], mkR 46 0 46 5]
   outL46 = Position 46  3  ;  outDef = [ExpectHoverText ["outer", "Bool"], mkR 46 0 46 5]
-  innL48 = Position 48  5  ;  innSig = [ExpectHoverText ["inner", "Char"], mkR 48 2 48 7]
+  innL48 = Position 48  5  ;  innSig = [ExpectHoverText ["inner", "Char"], mkR 49 2 49 7]
   innL49 = Position 49  5  ;  innDef = [ExpectHoverText ["inner", "Char"], mkR 49 2 49 7]
   in
   mkFindTests
@@ -1136,7 +1136,7 @@ findDefinitionAndHoverTests = let
   , test no     broken txtL8  litT   "literal Text in hover info      #274"
   , test no     broken lstL43 litL   "literal List in hover info      #274"
   , test no     broken docL41 constr "type constraint in hover info   #283"
-  , test no     broken outL45 outSig "top-level signature             #310"
+  , test broken broken outL45 outSig "top-level signature             #310"
   , test yes    yes    outL46 outDef "top-level definition            #310"
   , test broken broken innL48 innSig "inner     signature             #310"
   , test yes    yes    innL49 innDef "inner     definition            #310"

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -1098,9 +1098,7 @@ findDefinitionAndHoverTests = let
   txtL8  = Position  8 14  ;  litT   = [ExpectHoverText ["\"dfgv\""]]
   lstL43 = Position 43 12  ;  litL   = [ExpectHoverText ["[ 8391 :: Int, 6268 ]"]]
   outL45 = Position 45  3  ;  outSig = [ExpectHoverText ["outer", "Bool"], mkR 46 0 46 5]
-  outL46 = Position 46  3  ;  outDef = [ExpectHoverText ["outer", "Bool"], mkR 46 0 46 5]
   innL48 = Position 48  5  ;  innSig = [ExpectHoverText ["inner", "Char"], mkR 49 2 49 7]
-  innL49 = Position 49  5  ;  innDef = [ExpectHoverText ["inner", "Char"], mkR 49 2 49 7]
   in
   mkFindTests
   --     def    hover  look   expect
@@ -1137,9 +1135,7 @@ findDefinitionAndHoverTests = let
   , test no     broken lstL43 litL   "literal List in hover info      #274"
   , test no     broken docL41 constr "type constraint in hover info   #283"
   , test broken broken outL45 outSig "top-level signature             #310"
-  , test yes    yes    outL46 outDef "top-level definition            #310"
   , test broken broken innL48 innSig "inner     signature             #310"
-  , test yes    yes    innL49 innDef "inner     definition            #310"
   ]
   where yes, broken :: (TestTree -> Maybe TestTree)
         yes    = Just -- test should run and pass

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -1097,6 +1097,10 @@ findDefinitionAndHoverTests = let
   chrL36 = Position 36 25  ;  litC   = [ExpectHoverText ["'t'"]]
   txtL8  = Position  8 14  ;  litT   = [ExpectHoverText ["\"dfgv\""]]
   lstL43 = Position 43 12  ;  litL   = [ExpectHoverText ["[ 8391 :: Int, 6268 ]"]]
+  outL45 = Position 45  3  ;  outSig = [ExpectHoverText ["outer", "Bool"], mkR 45 0 45 5]
+  outL46 = Position 46  3  ;  outDef = [ExpectHoverText ["outer", "Bool"], mkR 46 0 46 5]
+  innL48 = Position 48  5  ;  innSig = [ExpectHoverText ["inner", "Char"], mkR 48 2 48 7]
+  innL49 = Position 49  5  ;  innDef = [ExpectHoverText ["inner", "Char"], mkR 49 2 49 7]
   in
   mkFindTests
   --     def    hover  look   expect
@@ -1132,6 +1136,10 @@ findDefinitionAndHoverTests = let
   , test no     broken txtL8  litT   "literal Text in hover info      #274"
   , test no     broken lstL43 litL   "literal List in hover info      #274"
   , test no     broken docL41 constr "type constraint in hover info   #283"
+  , test no     broken outL45 outSig "top-level signature             #310"
+  , test yes    yes    outL46 outDef "top-level definition            #310"
+  , test broken broken innL48 innSig "inner     signature             #310"
+  , test yes    yes    innL49 innDef "inner     definition            #310"
   ]
   where yes, broken :: (TestTree -> Maybe TestTree)
         yes    = Just -- test should run and pass


### PR DESCRIPTION
Tests for #310.

The most important pair of tests here is the "inner signature" pair. The others
serve mainly to document, compare and contrast what is happening in related
situations.

In summary, hover and gotoDef

+ on inner signatures: give type and location information for the outer
  definition; this is misleading,

+ on outer signatures: give no information at all,

+ on inner definitions: give correct information for the inner definition,

+ on outer definitions: give correct information for the outer definition.

Should hover and gotoDef do anything at all for signatures? or is the current
behaviour for outer signatures (doing nothing at all) what we want?