### PR TITLE
Trigger completion after dot

### DIFF
--- a/src/Development/IDE/LSP/Completions.hs
+++ b/src/Development/IDE/LSP/Completions.hs
@@ -22,7 +22,10 @@ getCompletionsLSP
     -> IdeState
     -> CompletionParams
     -> IO CompletionResponseResult
-getCompletionsLSP lsp ide CompletionParams{_textDocument=TextDocumentIdentifier uri,_position=position} = do
+getCompletionsLSP lsp ide
+  CompletionParams{_textDocument=TextDocumentIdentifier uri
+                  ,_position=position
+                  ,_context=completionContext} = do
     contents <- LSP.getVirtualFileFunc lsp $ toNormalizedUri uri
     case (contents, uriToFilePath' uri) of
       (Just cnts, Just path) -> do
@@ -32,8 +35,10 @@ getCompletionsLSP lsp ide CompletionParams{_textDocument=TextDocumentIdentifier 
           Just ((cci', tm'), mapping) -> do
             let position' = fromCurrentPosition mapping position
             pfix <- maybe (return Nothing) (flip VFS.getCompletionPrefix cnts) position'
-            case pfix of
-              Just pfix' -> do
+            case (pfix, completionContext) of
+              (Just (VFS.PosPrefixInfo _ "" _ _), Just CompletionContext { _triggerCharacter = Just "."})
+                -> return (Completions $ List [])
+              (Just pfix', _) -> do
                 let fakeClientCapabilities = ClientCapabilities Nothing Nothing Nothing Nothing
                 Completions . List <$> getCompletions cci' (tmrModule tm') pfix' fakeClientCapabilities (WithSnippets True)
               _ -> return (Completions $ List [])

--- a/src/Development/IDE/LSP/LanguageServer.hs
+++ b/src/Development/IDE/LSP/LanguageServer.hs
@@ -206,6 +206,7 @@ data Message
 modifyOptions :: LSP.Options -> LSP.Options
 modifyOptions x = x{ LSP.textDocumentSync   = Just $ tweakTDS origTDS
                    , LSP.executeCommandCommands = Just ["typesignature.add"]
+                   , LSP.completionTriggerCharacters = Just "."
                    }
     where
         tweakTDS tds = tds{_openClose=Just True, _change=Just TdSyncIncremental, _save=Just $ SaveOptions Nothing}

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -67,7 +67,7 @@ initializeResponseTests = withResource acquire release tests where
     testGroup "initialize response capabilities"
     [ chk "   text doc sync"             _textDocumentSync  tds
     , chk "   hover"                         _hoverProvider (Just True)
-    , chk "   completion"               _completionProvider (Just $ CompletionOptions (Just False) Nothing Nothing)
+    , chk "   completion"               _completionProvider (Just $ CompletionOptions (Just False) (Just ["."]) Nothing)
     , chk "NO signature help"        _signatureHelpProvider  Nothing
     , chk "   goto definition"          _definitionProvider (Just True)
     , chk "NO goto type definition" _typeDefinitionProvider (Just $ GotoOptionsStatic False)


### PR DESCRIPTION
This PR makes `ghcide` request a completion every time a dot is pressed. So if you do `Prelude.`, you get the entire list of functions defined in that module.

There's some additional logic to check for the case `id .`, where you want to use `(.)` as the function composition operator. Simply stated, if before the dot we find nothing, and the completion is triggered by that same press of the dot, we give nothing back in return.