### PR TITLE
Fix source spans for multi-clause definitions

### DIFF
--- a/src/Development/IDE/Spans/Calculate.hs
+++ b/src/Development/IDE/Spans/Calculate.hs
@@ -23,6 +23,7 @@ import           Desugar
 import           GHC
 import           GhcMonad
 import           FastString (mkFastString)
+import           OccName
 import           Development.IDE.Types.Location
 import           Development.IDE.Spans.Type
 import           Development.IDE.GHC.Error (zeroSpan)
@@ -63,7 +64,8 @@ getSpanInfo mods tcm =
          es  = listifyAllSpans  tcs :: [LHsExpr GhcTc]
          ps  = listifyAllSpans' tcs :: [Pat GhcTc]
          ts  = listifyAllSpans $ tm_renamed_source tcm :: [LHsType GhcRn]
-     bts <- mapM (getTypeLHsBind tcm) bs -- binds
+     let funBinds = funBindMap $ tm_parsed_module tcm
+     bts <- mapM (getTypeLHsBind funBinds) bs -- binds
      ets <- mapM (getTypeLHsExpr tcm) es -- expressions
      pts <- mapM (getTypeLPat tcm)    ps -- patterns
      tts <- mapM (getLHsType tcm)     ts -- types
@@ -75,6 +77,14 @@ getSpanInfo mods tcm =
           | a `isSubspanOf` b = LT
           | b `isSubspanOf` a = GT
           | otherwise         = compare (srcSpanStart a) (srcSpanStart b)
+
+-- | The locations in the typechecked module are as precise as the ones in the parsed module.
+-- Therefore we build up a map from OccName to the corresponding definition in the parsed module
+-- to lookup precise locations for things like multi-clause function definitions.
+--
+-- For now this only contains FunBinds
+funBindMap :: ParsedModule -> OccEnv (HsBind GhcPs)
+funBindMap pm = mkOccEnv $ [ (occName $ unLoc f, bnd) | L _ (ValD _ bnd@FunBind{fun_id = f}) <- hsmodDecls $ unLoc $ pm_parsed_source pm ]
 
 getExports :: TypecheckedModule -> [(SpanSource, SrcSpan, Maybe Type)]
 getExports m
@@ -95,12 +105,15 @@ ieLNames _ = []
 
 -- | Get the name and type of a binding.
 getTypeLHsBind :: (GhcMonad m)
-               => TypecheckedModule
+               => OccEnv (HsBind GhcPs)
                -> LHsBind GhcTc
                -> m [(SpanSource, SrcSpan, Maybe Type)]
-getTypeLHsBind _ (L _spn FunBind{ fun_id = pid
-                                , fun_matches = MG{mg_alts=(L _ matches)}}) =
-  return [(Named (getName (unLoc pid)), getLoc match, Just (varType (unLoc pid))) | match <- matches ]
+getTypeLHsBind funBinds (L _spn FunBind{fun_id = pid})
+  | Just FunBind {fun_matches = MG{mg_alts=L _ matches}} <- lookupOccEnv funBinds (occName $ unLoc pid) =
+  return [(Named (getName (unLoc pid)), getLoc mc_fun, Just (varType (unLoc pid))) | match <- matches, FunRhs{mc_fun = mc_fun} <- [m_ctxt $ unLoc match] ]
+-- In theory this shouldn’t ever fail but if it does, we can at least show the first clause.
+getTypeLHsBind _ (L _spn FunBind{fun_id = pid,fun_matches = MG{}}) =
+  return [(Named $ getName (unLoc pid), getLoc pid, Just (varType (unLoc pid)))]
 getTypeLHsBind _ _ = return []
 
 -- | Get the name and type of an expression.

--- a/src/Development/IDE/Spans/Calculate.hs
+++ b/src/Development/IDE/Spans/Calculate.hs
@@ -31,6 +31,7 @@ import           Prelude hiding (mod)
 import           TcHsSyn
 import           Var
 import Development.IDE.Core.Compile
+import qualified Development.IDE.GHC.Compat as Compat
 import Development.IDE.GHC.Util
 
 
@@ -84,7 +85,7 @@ getSpanInfo mods tcm =
 --
 -- For now this only contains FunBinds
 funBindMap :: ParsedModule -> OccEnv (HsBind GhcPs)
-funBindMap pm = mkOccEnv $ [ (occName $ unLoc f, bnd) | L _ (ValD _ bnd@FunBind{fun_id = f}) <- hsmodDecls $ unLoc $ pm_parsed_source pm ]
+funBindMap pm = mkOccEnv $ [ (occName $ unLoc f, bnd) | L _ (Compat.ValD bnd@FunBind{fun_id = f}) <- hsmodDecls $ unLoc $ pm_parsed_source pm ]
 
 getExports :: TypecheckedModule -> [(SpanSource, SrcSpan, Maybe Type)]
 getExports m

--- a/src/Development/IDE/Spans/Calculate.hs
+++ b/src/Development/IDE/Spans/Calculate.hs
@@ -79,11 +79,12 @@ getSpanInfo mods tcm =
           | b `isSubspanOf` a = GT
           | otherwise         = compare (srcSpanStart a) (srcSpanStart b)
 
--- | The locations in the typechecked module are as precise as the ones in the parsed module.
+-- | The locations in the typechecked module are slightly messed up in some cases (e.g. HsMatchContext always
+-- points to the first match) whereas the parsed module has the correct locations.
 -- Therefore we build up a map from OccName to the corresponding definition in the parsed module
 -- to lookup precise locations for things like multi-clause function definitions.
 --
--- For now this only contains FunBinds
+-- For now this only contains FunBinds.
 funBindMap :: ParsedModule -> OccEnv (HsBind GhcPs)
 funBindMap pm = mkOccEnv $ [ (occName $ unLoc f, bnd) | L _ (Compat.ValD bnd@FunBind{fun_id = f}) <- hsmodDecls $ unLoc $ pm_parsed_source pm ]
 

--- a/test/data/GotoHover.hs
+++ b/test/data/GotoHover.hs
@@ -34,7 +34,7 @@ listCompBind :: [Char]
 listCompBind = [ succ c | c <- "ptfx" ]
 
 multipleClause :: Bool -> Char
-multipleClause True  = 't'
+multipleClause True  =    't'
 multipleClause False = 'f'
 
 -- | Recognizable docs: kpqz


### PR DESCRIPTION
Currently, we use the source span of the match which corresponds to
the whole clause instead of just the function identifier. This
resulted in us pointing every goto definition request within a clause
to the function if there is no other information (either because it
failed because it came from an external package or simply because you
are not on an identifier).

This PR fixes this by getting the proper source spans frmo the
HsMatchContext. Somewhat annoyingly, we have to get it from the parsed
module since GHC messes this up during typechecking but it’s
reasonably simple.

fixes #315 