### PR TITLE
Fix performance of getFileExists

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -93,10 +93,10 @@ main = do
             -- very important we only call loadSession once, and it's fast, so just do it before starting
             session <- loadSession dir
             let options = (defaultIdeOptions $ return session)
-                    { optReportProgress = clientSupportsProgress caps 
+                    { optReportProgress = clientSupportsProgress caps
                     , optShakeProfiling = argsShakeProfiling
                     }
-            initialise (mainRule >> action kick) getLspId event (logger minBound) options vfs
+            initialise caps (mainRule >> action kick) getLspId event (logger minBound) options vfs
     else do
         putStrLn $ "Ghcide setup tester in " ++ dir ++ "."
         putStrLn "Report bugs at https://github.com/digital-asset/ghcide/issues"
@@ -125,7 +125,7 @@ main = do
         let grab file = fromMaybe (head sessions) $ do
                 cradle <- Map.lookup file filesToCradles
                 Map.lookup cradle cradlesToSessions
-        ide <- initialise mainRule (pure $ IdInt 0) (showEvent lock) (logger Info) (defaultIdeOptions $ return $ return . grab) vfs
+        ide <- initialise def mainRule (pure $ IdInt 0) (showEvent lock) (logger Info) (defaultIdeOptions $ return $ return . grab) vfs
 
         putStrLn "\nStep 6/6: Type checking the files"
         setFilesOfInterest ide $ Set.fromList $ map toNormalizedFilePath files

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -121,6 +121,7 @@ library
         Development.IDE.Core.Debouncer
         Development.IDE.Core.Compile
         Development.IDE.Core.Preprocessor
+        Development.IDE.Core.FileExists
         Development.IDE.GHC.Compat
         Development.IDE.GHC.CPP
         Development.IDE.GHC.Error

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -222,4 +222,16 @@ test-suite ghcide-tests
         Development.IDE.Test
         Development.IDE.Test.Runfiles
     default-extensions:
+        BangPatterns
+        DeriveFunctor
+        DeriveGeneric
+        GeneralizedNewtypeDeriving
+        LambdaCase
+        NamedFieldPuns
         OverloadedStrings
+        RecordWildCards
+        ScopedTypeVariables
+        StandaloneDeriving
+        TupleSections
+        TypeApplications
+        ViewPatterns

--- a/src/Development/IDE/Core/FileExists.hs
+++ b/src/Development/IDE/Core/FileExists.hs
@@ -10,13 +10,15 @@ where
 
 import           Control.Concurrent.Extra
 import           Control.Exception
-import           Control.Monad
+import           Control.Monad.Extra
 import qualified Data.Aeson                    as A
 import           Data.Binary
 import qualified Data.ByteString.Lazy          as BS
 import           Data.Map.Strict                ( Map )
 import qualified Data.Map.Strict               as Map
+import           Data.Maybe
 import qualified Data.Text                     as T
+import           Development.IDE.Core.FileStore
 import           Development.IDE.Core.Shake
 import           Development.IDE.Types.Location
 import           Development.Shake
@@ -25,6 +27,7 @@ import           GHC.Generics
 import           Language.Haskell.LSP.Messages
 import           Language.Haskell.LSP.Types
 import           Language.Haskell.LSP.Types.Capabilities
+import qualified System.Directory as Dir
 
 -- | A map for tracking the file existence
 type FileExistsMap = (Map NormalizedFilePath Bool)
@@ -75,7 +78,7 @@ getFileExists fp = use_ GetFileExists fp
 -- | Installs the 'getFileExists' rules.
 --   Provides a fast implementation if client supports dynamic watched files.
 --   Creates a global state as a side effect in that case.
-fileExistsRules :: IO LspId -> ClientCapabilities -> (NormalizedFilePath -> Action Bool) -> Rules ()
+fileExistsRules :: IO LspId -> ClientCapabilities -> VFSHandle -> Rules ()
 fileExistsRules getLspId ClientCapabilities{_workspace}
   | Just WorkspaceClientCapabilities{_didChangeWatchedFiles} <- _workspace
   , Just DidChangeWatchedFilesClientCapabilities{_dynamicRegistration} <- _didChangeWatchedFiles
@@ -84,8 +87,8 @@ fileExistsRules getLspId ClientCapabilities{_workspace}
   | otherwise = fileExistsRulesSlow
 
 --   Requires an lsp client that provides WatchedFiles notifications.
-fileExistsRulesFast :: IO LspId -> (NormalizedFilePath -> Action Bool) -> Rules ()
-fileExistsRulesFast getLspId getFileExists = do
+fileExistsRulesFast :: IO LspId -> VFSHandle -> Rules ()
+fileExistsRulesFast getLspId vfs = do
   addIdeGlobal . FileExistsMapVar =<< liftIO (newVar [])
   defineEarlyCutoff $ \GetFileExists file -> do
     fileExistsMap <- getFileExistsMapUntracked
@@ -93,7 +96,7 @@ fileExistsRulesFast getLspId getFileExists = do
     case mbFilesWatched of
       Just fv -> pure (createKey fv, ([], Just fv))
       Nothing -> do
-        exist                   <- getFileExists file
+        exist                   <- liftIO $ getFileExistsVFS vfs file
         ShakeExtras { eventer } <- getShakeExtras
 
         -- add a listener for VFS Create/Delete file events,
@@ -123,15 +126,23 @@ fileExistsRulesFast getLspId getFileExists = do
 
     void $ eventer $ ReqRegisterCapability req
 
-fileExistsRulesSlow:: (NormalizedFilePath -> Action Bool) -> Rules ()
-fileExistsRulesSlow getFileExists = do
+fileExistsRulesSlow:: VFSHandle -> Rules ()
+fileExistsRulesSlow vfs = do
   defineEarlyCutoff $ \GetFileExists file -> do
     alwaysRerun
-    exist                   <- getFileExists file
+    exist <- liftIO $ getFileExistsVFS vfs file
     pure (createKey exist, ([], Just exist))
  where
   createKey = Just . BS.toStrict . encode
 
+getFileExistsVFS :: VFSHandle -> NormalizedFilePath -> IO Bool
+getFileExistsVFS vfs file = do
+    -- we deliberately and intentionally wrap the file as an FilePath WITHOUT mkAbsolute
+    -- so that if the file doesn't exist, is on a shared drive that is unmounted etc we get a properly
+    -- cached 'No' rather than an exception in the wrong place
+    handle (\(_ :: IOException) -> return False) $
+        (isJust <$> getVirtualFile vfs (filePathToUri' file)) ||^
+        Dir.doesFileExist (fromNormalizedFilePath file)
 
 --------------------------------------------------------------------------------------------------
 -- The message definitions below probably belong in haskell-lsp-types

--- a/src/Development/IDE/Core/FileExists.hs
+++ b/src/Development/IDE/Core/FileExists.hs
@@ -60,7 +60,7 @@ modifyFileExists state changes = do
     modifyVar_ var $ evaluate . Map.union changesMap
     let flushPreviousValues = do
           ShakeExtras { state } <- getShakeExtras
-          liftIO $ mapM_ (resetValue state GetFileExists . fst) changes
+          liftIO $ mapM_ (deleteValue state GetFileExists . fst) changes
     void $ shakeRun state [flushPreviousValues]
 
 -------------------------------------------------------------------------------------

--- a/src/Development/IDE/Core/FileExists.hs
+++ b/src/Development/IDE/Core/FileExists.hs
@@ -59,7 +59,6 @@ modifyFileExists state changes = do
   mask $ \_ -> do
     modifyVar_ var $ evaluate . Map.union changesMap
     let flushPreviousValues = do
-          ShakeExtras { state } <- getShakeExtras
           liftIO $ mapM_ (deleteValue state GetFileExists . fst) changes
     void $ shakeRun state [flushPreviousValues]
 

--- a/src/Development/IDE/Core/FileExists.hs
+++ b/src/Development/IDE/Core/FileExists.hs
@@ -74,6 +74,14 @@ instance Hashable GetFileExists
 instance Binary   GetFileExists
 
 -- | Returns True if the file exists
+--   Note that a file is not considered to exist unless it is saved to disk.
+--   In particular, VFS existence is not enough.
+--   Consider the following example:
+--     1. The file @A.hs@ containing the line @import B@ is added to the files of interest
+--        Since @B.hs@ is neither open nor exists, GetLocatedImports finds Nothing
+--     2. The editor creates a new buffer @B.hs@
+--        Unless the editor also sends a @DidChangeWatchedFile@ event, ghcide will not pick it up
+--        Most editors, e.g. VSCode, only send the event when the file is saved to disk.
 getFileExists :: NormalizedFilePath -> Action Bool
 getFileExists fp = use_ GetFileExists fp
 

--- a/src/Development/IDE/Core/FileExists.hs
+++ b/src/Development/IDE/Core/FileExists.hs
@@ -131,9 +131,7 @@ fileExistsRulesSlow vfs = do
   defineEarlyCutoff $ \GetFileExists file -> do
     alwaysRerun
     exist <- liftIO $ getFileExistsVFS vfs file
-    pure (createKey exist, ([], Just exist))
- where
-  createKey = Just . BS.toStrict . encode
+    pure (Just $ BS.toStrict $ encode exist, ([], Just exist))
 
 getFileExistsVFS :: VFSHandle -> NormalizedFilePath -> IO Bool
 getFileExistsVFS vfs file = do

--- a/src/Development/IDE/Core/FileExists.hs
+++ b/src/Development/IDE/Core/FileExists.hs
@@ -99,11 +99,10 @@ fileExistsRulesFast getFileExists = do
         -- add a listener for VFS Create/Delete file events,
         -- taking the FileExistsMap lock to prevent race conditions
         -- that would lead to multiple listeners for the same path
-        modifyFileExistsAction $ \x -> case Map.lookup file x of
-          Just{}  -> return x
-          Nothing -> do
-            addListener eventer file
-            return x
+        modifyFileExistsAction $ \x -> do
+          unless (Map.member file x) (addListener eventer file)
+          return x
+
         pure (createKey exist, ([], Just exist))
  where
   createKey = Just . BS.toStrict . encode

--- a/src/Development/IDE/Core/FileExists.hs
+++ b/src/Development/IDE/Core/FileExists.hs
@@ -1,0 +1,161 @@
+{-# LANGUAGE OverloadedLists      #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
+module Development.IDE.Core.FileExists
+  ( fileExistsRules
+  , modifyFileExists
+  , getFileExists
+  )
+where
+
+import           Control.Concurrent.Extra
+import           Control.Exception
+import           Control.Monad
+import qualified Data.Aeson                    as A
+import           Data.Binary
+import qualified Data.ByteString.Lazy          as BS
+import           Data.Map.Strict                ( Map )
+import qualified Data.Map.Strict               as Map
+import qualified Data.Text                     as T
+import           Development.IDE.Core.Shake
+import           Development.IDE.Types.Location
+import           Development.Shake
+import           Development.Shake.Classes
+import           GHC.Generics
+import           Language.Haskell.LSP.Messages
+import           Language.Haskell.LSP.Types
+import           Language.Haskell.LSP.Types.Capabilities
+
+-- | A map for tracking the file existence
+type FileExistsMap = (Map NormalizedFilePath Bool)
+
+-- | A wrapper around a mutable 'FileExistsMap'
+newtype FileExistsMapVar = FileExistsMapVar (Var FileExistsMap)
+
+instance IsIdeGlobal FileExistsMapVar
+
+-- | Grab the current global value of 'FileExistsMap' without acquiring a dependency
+getFileExistsMapUntracked :: Action FileExistsMap
+getFileExistsMapUntracked = do
+  FileExistsMapVar v <- getIdeGlobalAction
+  liftIO $ readVar v
+
+-- | Modify the global store of file exists
+modifyFileExistsAction :: (FileExistsMap -> IO FileExistsMap) -> Action ()
+modifyFileExistsAction f = do
+  FileExistsMapVar var <- getIdeGlobalAction
+  liftIO $ modifyVar_ var f
+
+-- | Modify the global store of file exists
+modifyFileExists :: IdeState -> [(NormalizedFilePath, Bool)] -> IO ()
+modifyFileExists state changes = do
+  FileExistsMapVar var <- getIdeGlobalState state
+  changesMap           <- evaluate $ Map.fromList changes
+  modifyVar_ var $ evaluate . Map.union changesMap
+  let flushPreviousValues = do
+        ShakeExtras { state } <- getShakeExtras
+        liftIO $ mapM_ (resetValue state GetFileExists . fst) changes
+  void $ shakeRun state [flushPreviousValues]
+
+-------------------------------------------------------------------------------------
+
+type instance RuleResult GetFileExists = Bool
+
+data GetFileExists = GetFileExists
+    deriving (Eq, Show, Typeable, Generic)
+
+instance NFData   GetFileExists
+instance Hashable GetFileExists
+instance Binary   GetFileExists
+
+-- | Returns True if the file exists
+getFileExists :: NormalizedFilePath -> Action Bool
+getFileExists fp = use_ GetFileExists fp
+
+-- | Installs the 'getFileExists' rules.
+--   Provides a fast implementation if client supports dynamic watched files.
+--   Creates a global state as a side effect in that case.
+fileExistsRules :: ClientCapabilities -> (NormalizedFilePath -> Action Bool) -> Rules ()
+fileExistsRules ClientCapabilities{_workspace}
+  | Just WorkspaceClientCapabilities{_didChangeWatchedFiles} <- _workspace
+  , Just DidChangeWatchedFilesClientCapabilities{_dynamicRegistration} <- _didChangeWatchedFiles
+  , Just True <- _dynamicRegistration
+  = fileExistsRulesFast
+  | otherwise = fileExistsRulesSlow
+
+--   Requires an lsp client that provides WatchedFiles notifications.
+fileExistsRulesFast :: (NormalizedFilePath -> Action Bool) -> Rules ()
+fileExistsRulesFast getFileExists = do
+  addIdeGlobal . FileExistsMapVar =<< liftIO (newVar [])
+  defineEarlyCutoff $ \GetFileExists file -> do
+    fileExistsMap <- getFileExistsMapUntracked
+    let mbFilesWatched = Map.lookup file fileExistsMap
+    case mbFilesWatched of
+      Just fv -> pure (createKey fv, ([], Just fv))
+      Nothing -> do
+        exist                   <- getFileExists file
+        ShakeExtras { eventer } <- getShakeExtras
+
+        -- add a listener for VFS Create/Delete file events,
+        -- taking the FileExistsMap lock to prevent race conditions
+        -- that would lead to multiple listeners for the same path
+        modifyFileExistsAction $ \x -> case Map.lookup file x of
+          Just{}  -> return x
+          Nothing -> do
+            addListener eventer file
+            return x
+        pure (createKey exist, ([], Just exist))
+ where
+  createKey = Just . BS.toStrict . encode
+  addListener eventer fp = do
+    let
+      req = RequestMessage "2.0" reqId ClientRegisterCapability regParams
+      reqId        = IdString fpAsId
+      fpAsId       = T.pack $ fromNormalizedFilePath fp
+      regParams    = RegistrationParams (List [registration])
+      registration = Registration fpAsId
+                                  WorkspaceDidChangeWatchedFiles
+                                  (Just (A.toJSON regOptions))
+      regOptions =
+        DidChangeWatchedFilesRegistrationOptions { watchers = List [watcher] }
+      watcher = FileSystemWatcher { globPattern = fromNormalizedFilePath fp
+                                  , kind        = Just 5 -- Create and Delete events only
+                                  }
+
+    void $ eventer $ ReqRegisterCapability req
+
+fileExistsRulesSlow:: (NormalizedFilePath -> Action Bool) -> Rules ()
+fileExistsRulesSlow getFileExists = do
+  defineEarlyCutoff $ \GetFileExists file -> do
+    alwaysRerun
+    exist                   <- getFileExists file
+    pure (createKey exist, ([], Just exist))
+ where
+  createKey = Just . BS.toStrict . encode
+
+
+--------------------------------------------------------------------------------------------------
+-- The message definitions below probably belong in haskell-lsp-types
+
+data DidChangeWatchedFilesRegistrationOptions = DidChangeWatchedFilesRegistrationOptions
+    { watchers :: List FileSystemWatcher
+    }
+
+instance A.ToJSON DidChangeWatchedFilesRegistrationOptions where
+  toJSON DidChangeWatchedFilesRegistrationOptions {..} =
+    A.object ["watchers" A..= watchers]
+
+data FileSystemWatcher = FileSystemWatcher
+    { -- | The glob pattern to watch.
+      --   For details on glob pattern syntax, check the spec: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#workspace_didChangeWatchedFiles
+      globPattern :: String
+        -- | The kind of event to subscribe to. Defaults to all.
+        --   Defined as a bitmap of Create(1), Change(2), and Delete(4)
+    , kind        :: Maybe Int
+    }
+
+instance A.ToJSON FileSystemWatcher where
+  toJSON FileSystemWatcher {..} =
+    A.object
+      $  ["globPattern" A..= globPattern]
+      ++ [ "kind" A..= x | Just x <- [kind] ]

--- a/src/Development/IDE/Core/FileExists.hs
+++ b/src/Development/IDE/Core/FileExists.hs
@@ -55,12 +55,12 @@ modifyFileExists state changes = do
   FileExistsMapVar var <- getIdeGlobalState state
   changesMap           <- evaluate $ Map.fromList changes
 
-  -- Mask to ensure that the previous values are flushed together with the map update
+  -- Masked to ensure that the previous values are flushed together with the map update
   mask $ \_ -> do
+    -- update the map
     modifyVar_ var $ evaluate . Map.union changesMap
-    let flushPreviousValues = do
-          liftIO $ mapM_ (deleteValue state GetFileExists . fst) changes
-    void $ shakeRun state [flushPreviousValues]
+    -- flush previous values
+    mapM_ (deleteValue state GetFileExists . fst) changes
 
 -------------------------------------------------------------------------------------
 

--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -4,7 +4,8 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Development.IDE.Core.FileStore(
-    getFileExists, getFileContents,
+    getFileContents,
+    getVirtualFile,
     setBufferModified,
     setSomethingModified,
     fileStoreRules,
@@ -26,7 +27,6 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe
 import qualified Data.Text as T
 import           Control.Monad.Extra
-import qualified System.Directory as Dir
 import           Development.Shake
 import           Development.Shake.Classes
 import           Control.Exception
@@ -188,15 +188,6 @@ ideTryIOException fp act =
 
 getFileContents :: NormalizedFilePath -> Action (FileVersion, Maybe StringBuffer)
 getFileContents = use_ GetFileContents
-
-getFileExists :: VFSHandle -> NormalizedFilePath -> IO Bool
-getFileExists vfs file = do
-    -- we deliberately and intentionally wrap the file as an FilePath WITHOUT mkAbsolute
-    -- so that if the file doesn't exist, is on a shared drive that is unmounted etc we get a properly
-    -- cached 'No' rather than an exception in the wrong place
-    handle (\(_ :: IOException) -> return False) $
-        (isJust <$> getVirtualFile vfs (filePathToUri' file)) ||^
-        Dir.doesFileExist (fromNormalizedFilePath file)
 
 fileStoreRules :: VFSHandle -> Rules ()
 fileStoreRules vfs = do

--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -143,6 +143,8 @@ getModificationTimeRule vfs =
     -- time spent checking file modifications (which happens on every change)
     -- from > 0.5s to ~0.15s.
     -- We might also want to try speeding this up on Windows at some point.
+    -- TODO leverage DidChangeWatchedFile lsp notifications on clients that
+    -- support them, as done for GetFileExists
     getModTime :: FilePath -> IO BS.ByteString
     getModTime f =
 #ifdef mingw32_HOST_OS

--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -89,16 +89,7 @@ makeLSPVFSHandle lspFuncs = VFSHandle
 -- | Get the contents of a file, either dirty (if the buffer is modified) or Nothing to mean use from disk.
 type instance RuleResult GetFileContents = (FileVersion, Maybe StringBuffer)
 
--- | Does the file exist.
-type instance RuleResult GetFileExists = Bool
-
 type instance RuleResult FingerprintSource = Fingerprint
-
-data GetFileExists = GetFileExists
-    deriving (Eq, Show, Generic)
-instance Hashable GetFileExists
-instance NFData   GetFileExists
-instance Binary   GetFileExists
 
 data GetFileContents = GetFileContents
     deriving (Eq, Show, Generic)

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -37,7 +37,8 @@ import Development.IDE.Types.Options
 import Development.IDE.Spans.Calculate
 import Development.IDE.Import.DependencyInformation
 import Development.IDE.Import.FindImports
-import           Development.IDE.Core.FileStore
+import           Development.IDE.Core.FileExists
+import           Development.IDE.Core.FileStore        (getFileContents, getSourceFingerprint)
 import           Development.IDE.Types.Diagnostics
 import Development.IDE.Types.Location
 import Development.IDE.GHC.Util

--- a/src/Development/IDE/Core/Service.hs
+++ b/src/Development/IDE/Core/Service.hs
@@ -23,13 +23,15 @@ import           Control.Concurrent.Async
 import Data.Maybe
 import Development.IDE.Types.Options (IdeOptions(..))
 import Control.Monad
-import           Development.IDE.Core.FileStore
+import           Development.IDE.Core.FileStore  (VFSHandle, fileStoreRules, getFileExists)
+import           Development.IDE.Core.FileExists (fileExistsRules)
 import           Development.IDE.Core.OfInterest
 import Development.IDE.Types.Logger
 import           Development.Shake
 import Data.Either.Extra
 import qualified Language.Haskell.LSP.Messages as LSP
 import qualified Language.Haskell.LSP.Types as LSP
+import qualified Language.Haskell.LSP.Types.Capabilities as LSP
 
 import           Development.IDE.Core.Shake
 
@@ -42,14 +44,15 @@ instance IsIdeGlobal GlobalIdeOptions
 -- Exposed API
 
 -- | Initialise the Compiler Service.
-initialise :: Rules ()
+initialise :: LSP.ClientCapabilities
+           -> Rules ()
            -> IO LSP.LspId
            -> (LSP.FromServerMessage -> IO ())
            -> Logger
            -> IdeOptions
            -> VFSHandle
            -> IO IdeState
-initialise mainRule getLspId toDiags logger options vfs =
+initialise caps mainRule getLspId toDiags logger options vfs =
     shakeOpen
         getLspId
         toDiags
@@ -63,6 +66,7 @@ initialise mainRule getLspId toDiags logger options vfs =
             addIdeGlobal $ GlobalIdeOptions options
             fileStoreRules vfs
             ofInterestRules
+            fileExistsRules caps (liftIO . getFileExists vfs)
             mainRule
 
 writeProfile :: IdeState -> FilePath -> IO ()

--- a/src/Development/IDE/Core/Service.hs
+++ b/src/Development/IDE/Core/Service.hs
@@ -66,7 +66,7 @@ initialise caps mainRule getLspId toDiags logger options vfs =
             addIdeGlobal $ GlobalIdeOptions options
             fileStoreRules vfs
             ofInterestRules
-            fileExistsRules caps (liftIO . getFileExists vfs)
+            fileExistsRules getLspId caps (liftIO . getFileExists vfs)
             mainRule
 
 writeProfile :: IdeState -> FilePath -> IO ()

--- a/src/Development/IDE/Core/Service.hs
+++ b/src/Development/IDE/Core/Service.hs
@@ -23,7 +23,7 @@ import           Control.Concurrent.Async
 import Data.Maybe
 import Development.IDE.Types.Options (IdeOptions(..))
 import Control.Monad
-import           Development.IDE.Core.FileStore  (VFSHandle, fileStoreRules, getFileExists)
+import           Development.IDE.Core.FileStore  (VFSHandle, fileStoreRules)
 import           Development.IDE.Core.FileExists (fileExistsRules)
 import           Development.IDE.Core.OfInterest
 import Development.IDE.Types.Logger
@@ -66,7 +66,7 @@ initialise caps mainRule getLspId toDiags logger options vfs =
             addIdeGlobal $ GlobalIdeOptions options
             fileStoreRules vfs
             ofInterestRules
-            fileExistsRules getLspId caps (liftIO . getFileExists vfs)
+            fileExistsRules getLspId caps vfs
             mainRule
 
 writeProfile :: IdeState -> FilePath -> IO ()

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -39,7 +39,7 @@ module Development.IDE.Core.Shake(
     FileVersion(..),
     Priority(..),
     updatePositionMapping,
-    resetValue,
+    deleteValue,
     OnDiskRule(..),
     ) where
 
@@ -260,13 +260,13 @@ setValues state key file val = modifyVar_ state $ \vals -> do
     evaluate $ HMap.insert (file, Key key) (fmap toDyn val) vals
 
 -- | Delete the value stored for a given ide build key
-resetValue
+deleteValue
   :: (Typeable k, Hashable k, Eq k, Show k)
   => Var Values
   -> k
   -> NormalizedFilePath
   -> IO ()
-resetValue state key file = modifyVar_ state $ \vals ->
+deleteValue state key file = modifyVar_ state $ \vals ->
     evaluate $ HMap.delete (file, Key key) vals
 
 -- | We return Nothing if the rule has not run and Just Failed if it has failed to produce a value.

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -262,11 +262,11 @@ setValues state key file val = modifyVar_ state $ \vals -> do
 -- | Delete the value stored for a given ide build key
 deleteValue
   :: (Typeable k, Hashable k, Eq k, Show k)
-  => Var Values
+  => IdeState
   -> k
   -> NormalizedFilePath
   -> IO ()
-deleteValue state key file = modifyVar_ state $ \vals ->
+deleteValue IdeState{shakeExtras = ShakeExtras{state}} key file = modifyVar_ state $ \vals ->
     evaluate $ HMap.delete (file, Key key) vals
 
 -- | We return Nothing if the rule has not run and Just Failed if it has failed to produce a value.

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -20,6 +20,7 @@
 --   between runs. To deserialise a Shake value, we just consult Values.
 module Development.IDE.Core.Shake(
     IdeState,
+    ShakeExtras(..), getShakeExtras,
     IdeRule, IdeResult, GetModificationTime(..),
     shakeOpen, shakeShut,
     shakeRun,
@@ -38,7 +39,8 @@ module Development.IDE.Core.Shake(
     FileVersion(..),
     Priority(..),
     updatePositionMapping,
-    OnDiskRule(..)
+    resetValue,
+    OnDiskRule(..),
     ) where
 
 import           Development.Shake hiding (ShakeValue, doesFileExist)
@@ -256,6 +258,16 @@ setValues :: IdeRule k v
 setValues state key file val = modifyVar_ state $ \vals -> do
     -- Force to make sure the old HashMap is not retained
     evaluate $ HMap.insert (file, Key key) (fmap toDyn val) vals
+
+-- | Delete the value stored for a given ide build key
+resetValue
+  :: (Typeable k, Hashable k, Eq k, Show k)
+  => Var Values
+  -> k
+  -> NormalizedFilePath
+  -> IO ()
+resetValue state key file = modifyVar_ state $ \vals ->
+    evaluate $ HMap.delete (file, Key key) vals
 
 -- | We return Nothing if the rule has not run and Just Failed if it has failed to produce a value.
 getValues :: forall k v. IdeRule k v => Var Values -> k -> NormalizedFilePath -> IO (Maybe (Value v))

--- a/src/Development/IDE/LSP/Notifications.hs
+++ b/src/Development/IDE/LSP/Notifications.hs
@@ -2,26 +2,30 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RankNTypes            #-}
 
 module Development.IDE.LSP.Notifications
     ( setHandlersNotifications
     ) where
 
-import           Language.Haskell.LSP.Types
 import           Development.IDE.LSP.Server
-import qualified Language.Haskell.LSP.Core as LSP
-import qualified Language.Haskell.LSP.Types as LSP
+import qualified Language.Haskell.LSP.Core        as LSP
+import           Language.Haskell.LSP.Types
+import qualified Language.Haskell.LSP.Types       as LSP
 
-import Development.IDE.Types.Logger
-import Development.IDE.Core.Service
-import Development.IDE.Types.Location
+import           Development.IDE.Core.Service
+import           Development.IDE.Types.Location
+import           Development.IDE.Types.Logger
 
-import Control.Monad.Extra
-import qualified Data.Set                                  as S
+import           Control.Monad.Extra
+import           Data.Foldable                    as F
+import           Data.Maybe
+import qualified Data.Set                         as S
+import qualified Data.Text                        as Text
 
-import Development.IDE.Core.FileStore
-import Development.IDE.Core.OfInterest
+import           Development.IDE.Core.FileStore   (setSomethingModified)
+import           Development.IDE.Core.FileExists  (modifyFileExists)
+import           Development.IDE.Core.OfInterest
 
 
 whenUriFile :: Uri -> (NormalizedFilePath -> IO ()) -> IO ()
@@ -52,4 +56,16 @@ setHandlersNotifications = PartialHandlers $ \WithMessage{..} x -> return x
             whenUriFile _uri $ \file -> do
                 modifyFilesOfInterest ide (S.delete file)
                 logInfo (ideLogger ide) $ "Closed text document: " <> getUri _uri
+    ,LSP.didChangeWatchedFilesNotificationHandler = withNotification (LSP.didChangeWatchedFilesNotificationHandler x) $
+        \_ ide (DidChangeWatchedFilesParams fileEvents) -> do
+            let events =
+                    mapMaybe
+                        (\(FileEvent uri ev) ->
+                            (, ev /= FcDeleted) . toNormalizedFilePath
+                            <$> LSP.uriToFilePath uri
+                        )
+                        ( F.toList fileEvents )
+            let msg = Text.pack $ show events
+            logInfo (ideLogger ide) $ "Files created or deleted: " <> msg
+            modifyFileExists ide events
     }

--- a/src/Development/IDE/LSP/Notifications.hs
+++ b/src/Development/IDE/LSP/Notifications.hs
@@ -68,4 +68,5 @@ setHandlersNotifications = PartialHandlers $ \WithMessage{..} x -> return x
             let msg = Text.pack $ show events
             logInfo (ideLogger ide) $ "Files created or deleted: " <> msg
             modifyFileExists ide events
+            setSomethingModified ide
     }

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -14,6 +14,7 @@ import Control.Monad
 import Control.Monad.IO.Class (liftIO)
 import Data.Char (toLower)
 import Data.Foldable
+import Data.Functor
 import Data.List
 import Development.IDE.GHC.Util
 import qualified Data.Text as T
@@ -1532,7 +1533,12 @@ run s = withTempDir $ \dir -> do
   -- HIE calls getXgdDirectory which assumes that HOME is set.
   -- Only sets HOME if it wasn't already set.
   setEnv "HOME" "/homeless-shelter" False
-  runSessionWithConfig conf cmd fullCaps { _window = Just $ WindowClientCapabilities $ Just True } dir s
+  let lspTestCaps =
+        fullCaps
+          { _window = Just $ WindowClientCapabilities $ Just True
+          , _workspace = _workspace (fullCaps :: ClientCapabilities) <&> \x -> x{ _didChangeWatchedFiles = Nothing }
+          }
+  runSessionWithConfig conf cmd lspTestCaps dir s
   where
     conf = defaultConfig
       -- If you uncomment this you can see all logging


### PR DESCRIPTION
This is a minimal solution that does not entirely follow the plan in #101, focusing on GetFileExists instead of GetLocatedImports. 

In my experiments it solves the problem, hopefully without breaking anything else. Checked with VSCode only. 

Adding tests is tricky since lsp-test does not send DidChangeWatchedFiles notifications. I'm open to suggestions on what to do.

Leveraging DidChangeWatchedFiles notifications for other purposes, e.g. in the GetModificationTime rule, is left for future PRs.