### PR TITLE
Avoid lookupName on ghc-lib

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -76,6 +76,7 @@
   - {name: ImplicitParams, within: []}
   - name: CPP
     within:
+    - Development.IDE.Core.Completions
     - Development.IDE.Core.FileStore
     - Development.IDE.Core.Compile
     - Development.IDE.GHC.Compat


### PR DESCRIPTION
This fixes an issue that we encountered in DAML. I’ll add a test for
this in the DAML repo since we cannot test the ghc-lib codepath
here (since we don’t setup an environment that works).