### PR TITLE
GC tweaks

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -151,7 +151,18 @@ executable ghcide
       buildable: False
     default-language:   Haskell2010
     hs-source-dirs:     exe
-    ghc-options: -threaded -Wall -Wno-name-shadowing
+    ghc-options:
+                -threaded
+                -Wall
+                -Wno-name-shadowing
+                -- allow user RTS overrides
+                -rtsopts
+                -- disable idle GC
+                -with-rtsopts=-I0
+                -- disable parallel GC
+                -with-rtsopts=-qg
+                -- increase nursery size
+                -with-rtsopts=-A128M
     main-is: Main.hs
     build-depends:
         hslogger,


### PR DESCRIPTION
ghcide uses a lot of memory in large codebases. In ours it starts at 7GB and goes up to 30GB quite easily. Needless to say, GC settings have a huge impact. Disabling the idle GC alone cuts up to 4s for hovers.