### PR TITLE
Fix -with-rtsopts flags to work as intended

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -158,11 +158,9 @@ executable ghcide
                 -- allow user RTS overrides
                 -rtsopts
                 -- disable idle GC
-                -with-rtsopts=-I0
                 -- disable parallel GC
-                -with-rtsopts=-qg
                 -- increase nursery size
-                -with-rtsopts=-A128M
+                "-with-rtsopts=-I0 -qg -A128M"
     main-is: Main.hs
     build-depends:
         hslogger,


### PR DESCRIPTION
GHC does not support multiple `-with-rtsopts` flags: the last one wins

Before this change:
```
[nix-shell:~/scratch/ghcide]$ /home/pepe/scratch/ghcide/dist-newstyle/build/x86_64-linux/ghc-8.8.1/ghcide-0.0.6/x/ghcide/build/ghcide/ghcide  +RTS --info
 [("GHC RTS", "YES")
 ,("GHC version", "8.8.1")
 ,("RTS way", "rts_thr_p")
 ,("Build platform", "x86_64-unknown-linux")
 ,("Build architecture", "x86_64")
 ,("Build OS", "linux")
 ,("Build vendor", "unknown")
 ,("Host platform", "x86_64-unknown-linux")
 ,("Host architecture", "x86_64")
 ,("Host OS", "linux")
 ,("Host vendor", "unknown")
 ,("Target platform", "x86_64-unknown-linux")
 ,("Target architecture", "x86_64")
 ,("Target OS", "linux")
 ,("Target vendor", "unknown")
 ,("Word size", "64")
 ,("Compiler unregisterised", "NO")
 ,("Tables next to code", "YES")
 ,("Flag -with-rtsopts", "-A128M")
 ]
```
After this change:
```
[nix-shell:~/scratch/ghcide]$ /home/pepe/scratch/ghcide/dist-newstyle/build/x86_64-linux/ghc-8.8.1/ghcide-0.0.6/x/ghcide/build/ghcide/ghcide  +RTS --info
 [("GHC RTS", "YES")
 ,("GHC version", "8.8.1")
 ,("RTS way", "rts_thr")
 ,("Build platform", "x86_64-unknown-linux")
 ,("Build architecture", "x86_64")
 ,("Build OS", "linux")
 ,("Build vendor", "unknown")
 ,("Host platform", "x86_64-unknown-linux")
 ,("Host architecture", "x86_64")
 ,("Host OS", "linux")
 ,("Host vendor", "unknown")
 ,("Target platform", "x86_64-unknown-linux")
 ,("Target architecture", "x86_64")
 ,("Target OS", "linux")
 ,("Target vendor", "unknown")
 ,("Word size", "64")
 ,("Compiler unregisterised", "NO")
 ,("Tables next to code", "YES")
 ,("Flag -with-rtsopts", "-I0 -qg -A128M")
 ]
```