### PR TITLE
Fix build on Windows/MinGW

### DIFF
--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -40,6 +40,7 @@ import qualified Data.Rope.UTF16 as Rope
 
 #ifdef mingw32_HOST_OS
 import Data.Time
+import qualified System.Directory as Dir
 #else
 import Foreign.C.String
 import Foreign.C.Types


### PR DESCRIPTION
This was causing the following error when trying to build under MinGW:

    [28 of 38] Compiling Development.IDE.Core.FileStore

    C:\Snapshot\src\ghcide\src\Development\IDE\Core\FileStore.hs:142:20: error:
        Not in scope: `Dir.getModificationTime'
        No module named `Dir' is imported.
        |
    142 |         do time <- Dir.getModificationTime f
        |                    ^^^^^^^^^^^^^^^^^^^^^^^

---

I came across this while working on #336, which I happened to troubleshoot under a Windows machine.