### PR TITLE
Show constraints on hover

### DIFF
--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -63,7 +63,7 @@ instance NFData TcModuleResult where
 type instance RuleResult TypeCheck = TcModuleResult
 
 -- | Information about what spans occur where, requires TypeCheck
-type instance RuleResult GetSpanInfo = [SpanInfo]
+type instance RuleResult GetSpanInfo = SpansInfo
 
 -- | Convert to Core, requires TypeCheck*
 type instance RuleResult GenerateCore = (SafeHaskellMode, CgGuts, ModDetails)

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -54,6 +54,7 @@ import qualified Data.Text                                as T
 import           Development.IDE.GHC.Error
 import           Development.Shake                        hiding (Diagnostic)
 import Development.IDE.Core.RuleTypes
+import Development.IDE.Spans.Type
 
 import           GHC hiding (parseModule, typecheckModule)
 import qualified GHC.LanguageExtensions as LangExt
@@ -114,7 +115,7 @@ getDefinition file pos = fmap join $ runMaybeT $ do
     spans <- useE GetSpanInfo file
     pkgState <- hscEnv <$> useE GhcSession file
     let getHieFile x = useNoFile (GetHieFile x)
-    lift $ AtPoint.gotoDefinition getHieFile opts pkgState spans pos
+    lift $ AtPoint.gotoDefinition getHieFile opts pkgState (spansExprs spans) pos
 
 -- | Parse the contents of a daml file.
 getParsedModule :: NormalizedFilePath -> Action (Maybe ParsedModule)

--- a/src/Development/IDE/Spans/Type.hs
+++ b/src/Development/IDE/Spans/Type.hs
@@ -6,7 +6,8 @@
 -- | Types used separate to GHCi vanilla.
 
 module Development.IDE.Spans.Type(
-    SpanInfo(..)
+    SpansInfo(..)
+  , SpanInfo(..)
   , SpanSource(..)
   , getNameM
   ) where
@@ -16,6 +17,14 @@ import Control.DeepSeq
 import OccName
 import Development.IDE.GHC.Util
 import Development.IDE.Spans.Common
+
+data SpansInfo =
+  SpansInfo { spansExprs       :: [SpanInfo]
+            , spansConstraints :: [SpanInfo] }
+  deriving Show
+
+instance NFData SpansInfo where
+  rnf (SpansInfo e c) = liftRnf rnf e `seq` liftRnf rnf c
 
 -- | Type of some span of source code. Most of these fields are
 -- unboxed but Haddock doesn't show that.

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -1146,7 +1146,7 @@ findDefinitionAndHoverTests = let
   mclL37 = Position 37  1
   spaceL37 = Position 37  24 ; space = [ExpectNoDefinitions, ExpectHoverText [":: Char"]]
   docL41 = Position 41  1  ;  doc    = [ExpectHoverText ["Recognizable docs: kpqz"]]
-                           ;  constr = [ExpectHoverText ["Monad m =>"]]
+                           ;  constr = [ExpectHoverText ["Monad m"]]
   eitL40 = Position 40 28  ;  kindE  = [ExpectHoverText [":: * -> * -> *\n"]]
   intL40 = Position 40 34  ;  kindI  = [ExpectHoverText [":: *\n"]]
   tvrL40 = Position 40 37  ;  kindV  = [ExpectHoverText [":: * -> *\n"]]
@@ -1191,7 +1191,7 @@ findDefinitionAndHoverTests = let
   , test no     yes    chrL36 litC   "literal Char in hover info      #274"
   , test no     broken txtL8  litT   "literal Text in hover info      #274"
   , test no     broken lstL43 litL   "literal List in hover info      #274"
-  , test no     broken docL41 constr "type constraint in hover info   #283"
+  , test no     yes    docL41 constr "type constraint in hover info   #283"
   , test broken broken outL45 outSig "top-level signature             #310"
   , test broken broken innL48 innSig "inner     signature             #310"
   ]


### PR DESCRIPTION
Fixes #283.

The implementation works by collecting constraints from `AbsBinds`, and then filtering those which are in the range of the variable to show and which have some free variable in common with the type to be shown. The new `SpansInfo` type collect info for both expressions and types.