### PR TITLE
Disable getDocs call with ghc-lib

### DIFF
--- a/src/Development/IDE/Spans/Documentation.hs
+++ b/src/Development/IDE/Spans/Documentation.hs
@@ -26,7 +26,9 @@ getDocumentationTryGhc
   => [TypecheckedModule]
   -> Name
   -> m SpanDoc
-#if MIN_GHC_API_VERSION(8,6,0)
+-- getDocs goes through the GHCi codepaths which cause problems on ghc-lib.
+-- See https://github.com/digital-asset/daml/issues/4152 for more details.
+#if MIN_GHC_API_VERSION(8,6,0) && !defined(GHC_LIB)
 getDocumentationTryGhc tcs name = do
   res <- catchSrcErrors "docs" $ getDocs name
   case res of


### PR DESCRIPTION
This has caused a bunch of issues in DAML where GHC seems to randomly
panics when completions are requested, see
https://github.com/digital-asset/daml/issues/4152 for the error. I am
not entirely sure what is going wrong there but `getDocs` also goes
through the GHCi codepaths which are known to cause issues with
ghc-lib so for now, let’s disable it.