### PR TITLE
#346, don't use nameModule, which raises errors

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -97,9 +97,12 @@
 #   - {name: Control.Arrow, within: []} # Certain modules are banned entirely
 #
 - functions:
+  # Things that are unsafe in Haskell base library
   - {name: unsafeInterleaveIO, within: []}
   - {name: unsafeDupablePerformIO, within: []}
   - {name: unsafeCoerce, within: []}
+  # Things that are a bit dangerous in the GHC API
+  - {name: nameModule, within: []}
 
 # Add custom hints for this project
 #

--- a/src/Development/IDE/Spans/AtPoint.hs
+++ b/src/Development/IDE/Spans/AtPoint.hs
@@ -133,7 +133,7 @@ locationsAtPoint getHieFile IdeOptions{..} pkgState pos =
                 -- This case usually arises when the definition is in an external package.
                 -- In this case the interface files contain garbage source spans
                 -- so we instead read the .hie files to get useful source spans.
-                let mod = nameModule name
+                mod <- MaybeT $ return $ nameModule_maybe name
                 let unitId = moduleUnitId mod
                 pkgConfig <- MaybeT $ pure $ lookupPackageConfig unitId pkgState
                 hiePath <- MaybeT $ liftIO $ optLocateHieFile optPkgLocationOpts pkgConfig mod
@@ -147,7 +147,7 @@ locationsAtPoint getHieFile IdeOptions{..} pkgState pos =
                 pure span
         -- We ignore uniques and source spans and only compare the name and the module.
         eqName :: Name -> Name -> Bool
-        eqName n n' = nameOccName n == nameOccName n' && nameModule n == nameModule n'
+        eqName n n' = nameOccName n == nameOccName n' && nameModule_maybe n == nameModule_maybe n'
         setFileName f (RealSrcSpan span) = RealSrcSpan (span { srcSpanFile = mkFastString f })
         setFileName _ span@(UnhelpfulSpan _) = span
 


### PR DESCRIPTION
Fixes #346.

I never managed to reproduce the bug, but the nameModule function seems destined to cause random issues - it works on 99% of identifiers, so goes wrong in a few corner cases. Using the `_maybe` variant is simple and safer.