### PR TITLE
Move the completions and code actions into Plugin

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -76,7 +76,6 @@
   - {name: ImplicitParams, within: []}
   - name: CPP
     within:
-    - Development.IDE.Core.Completions
     - Development.IDE.Core.FileStore
     - Development.IDE.Core.Compile
     - Development.IDE.GHC.Compat
@@ -86,6 +85,7 @@
     - Development.IDE.Spans.Calculate
     - Development.IDE.Spans.Documentation
     - Development.IDE.Spans.Common
+    - Development.IDE.Plugin.Completions.Logic
     - Main
 
 - flags:

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -81,10 +81,10 @@
     - Development.IDE.GHC.Compat
     - Development.IDE.GHC.Util
     - Development.IDE.Import.FindImports
-    - Development.IDE.LSP.CodeAction
     - Development.IDE.Spans.Calculate
     - Development.IDE.Spans.Documentation
     - Development.IDE.Spans.Common
+    - Development.IDE.Plugin.CodeAction
     - Development.IDE.Plugin.Completions.Logic
     - Main
 

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -29,6 +29,7 @@ import Development.IDE.Types.Options
 import Development.IDE.Types.Logger
 import Development.IDE.GHC.Util
 import Development.IDE.Plugin.Completions
+import Development.IDE.Plugin.CodeAction
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Language.Haskell.LSP.Messages
@@ -84,11 +85,18 @@ main = do
 
     dir <- getCurrentDirectory
 
+    let handlers = def <>
+            setHandlersCompletion <>
+            setHandlersCodeAction <> setHandlersCodeLens
+    let rules = do
+            mainRule
+            produceCompletions
+
     if argLSP then do
         t <- offsetTime
         hPutStrLn stderr "Starting LSP server..."
         hPutStrLn stderr "If you are seeing this in a terminal, you probably should have run ghcidie WITHOUT the --lsp option!"
-        runLanguageServer def (def <> setHandlersCompletion) $ \getLspId event vfs caps -> do
+        runLanguageServer def handlers $ \getLspId event vfs caps -> do
             t <- t
             hPutStrLn stderr $ "Started LSP server in " ++ showDuration t
             -- very important we only call loadSession once, and it's fast, so just do it before starting
@@ -97,7 +105,7 @@ main = do
                     { optReportProgress = clientSupportsProgress caps
                     , optShakeProfiling = argsShakeProfiling
                     }
-            initialise caps (mainRule >> produceCompletions >> action kick) getLspId event (logger minBound) options vfs
+            initialise caps (rules >> action kick) getLspId event (logger minBound) options vfs
     else do
         putStrLn $ "Ghcide setup tester in " ++ dir ++ "."
         putStrLn "Report bugs at https://github.com/digital-asset/ghcide/issues"

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -85,7 +85,7 @@ main = do
 
     dir <- getCurrentDirectory
 
-    let handlers = def <>
+    let handlers =
             setHandlersCompletion <>
             setHandlersCodeAction <> setHandlersCodeLens
     let rules = do

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -28,6 +28,7 @@ import Development.IDE.Types.Diagnostics
 import Development.IDE.Types.Options
 import Development.IDE.Types.Logger
 import Development.IDE.GHC.Util
+import Development.IDE.Plugin.Completions
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Language.Haskell.LSP.Messages
@@ -87,7 +88,7 @@ main = do
         t <- offsetTime
         hPutStrLn stderr "Starting LSP server..."
         hPutStrLn stderr "If you are seeing this in a terminal, you probably should have run ghcidie WITHOUT the --lsp option!"
-        runLanguageServer def def $ \getLspId event vfs caps -> do
+        runLanguageServer def (def <> setHandlersCompletion) $ \getLspId event vfs caps -> do
             t <- t
             hPutStrLn stderr $ "Started LSP server in " ++ showDuration t
             -- very important we only call loadSession once, and it's fast, so just do it before starting
@@ -96,7 +97,7 @@ main = do
                     { optReportProgress = clientSupportsProgress caps
                     , optShakeProfiling = argsShakeProfiling
                     }
-            initialise caps (mainRule >> action kick) getLspId event (logger minBound) options vfs
+            initialise caps (mainRule >> produceCompletions >> action kick) getLspId event (logger minBound) options vfs
     else do
         putStrLn $ "Ghcide setup tester in " ++ dir ++ "."
         putStrLn "Report bugs at https://github.com/digital-asset/ghcide/issues"

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -116,6 +116,7 @@ library
         Development.IDE.Types.Logger
         Development.IDE.Types.Options
         Development.IDE.Plugin.Completions
+        Development.IDE.Plugin.CodeAction
     other-modules:
         Development.IDE.Core.Debouncer
         Development.IDE.Core.Compile
@@ -127,7 +128,6 @@ library
         Development.IDE.GHC.Orphans
         Development.IDE.GHC.Warnings
         Development.IDE.Import.FindImports
-        Development.IDE.LSP.CodeAction
         Development.IDE.LSP.HoverDefinition
         Development.IDE.LSP.Notifications
         Development.IDE.LSP.Outline

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -99,8 +99,6 @@ library
     include-dirs:
         include
     exposed-modules:
-        Development.IDE.Core.Completions
-        Development.IDE.Core.CompletionsTypes
         Development.IDE.Core.FileStore
         Development.IDE.Core.OfInterest
         Development.IDE.Core.PositionMapping
@@ -117,6 +115,7 @@ library
         Development.IDE.Types.Location
         Development.IDE.Types.Logger
         Development.IDE.Types.Options
+        Development.IDE.Plugin.Completions
     other-modules:
         Development.IDE.Core.Debouncer
         Development.IDE.Core.Compile
@@ -129,7 +128,6 @@ library
         Development.IDE.GHC.Warnings
         Development.IDE.Import.FindImports
         Development.IDE.LSP.CodeAction
-        Development.IDE.LSP.Completions
         Development.IDE.LSP.HoverDefinition
         Development.IDE.LSP.Notifications
         Development.IDE.LSP.Outline
@@ -138,6 +136,8 @@ library
         Development.IDE.Spans.Common
         Development.IDE.Spans.Documentation
         Development.IDE.Spans.Type
+        Development.IDE.Plugin.Completions.Logic
+        Development.IDE.Plugin.Completions.Types
     ghc-options: -Wall -Wno-name-shadowing
 
 executable ghcide-test-preprocessor

--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -27,7 +27,6 @@ import Module (InstalledUnitId)
 import HscTypes (CgGuts, Linkable, HomeModInfo, ModDetails)
 import Development.IDE.GHC.Compat
 
-import           Development.IDE.Core.CompletionsTypes
 import           Development.IDE.Spans.Type
 
 
@@ -85,9 +84,6 @@ type instance RuleResult ReportImportCycles = ()
 
 -- | Read the given HIE file.
 type instance RuleResult GetHieFile = HieFile
-
--- | Produce completions info for a file
-type instance RuleResult ProduceCompletions = (CachedCompletions, TcModuleResult)
 
 
 data GetParsedModule = GetParsedModule
@@ -157,9 +153,3 @@ data GetHieFile = GetHieFile FilePath
 instance Hashable GetHieFile
 instance NFData   GetHieFile
 instance Binary   GetHieFile
-
-data ProduceCompletions = ProduceCompletions
-    deriving (Eq, Show, Typeable, Generic)
-instance Hashable ProduceCompletions
-instance NFData   ProduceCompletions
-instance Binary   ProduceCompletions

--- a/src/Development/IDE/LSP/LanguageServer.hs
+++ b/src/Development/IDE/LSP/LanguageServer.hs
@@ -29,7 +29,6 @@ import System.IO
 import Control.Monad.Extra
 
 import Development.IDE.LSP.HoverDefinition
-import Development.IDE.LSP.CodeAction
 import Development.IDE.LSP.Notifications
 import Development.IDE.LSP.Outline
 import Development.IDE.Core.Service
@@ -97,7 +96,6 @@ runLanguageServer options userHandlers getIdeState = do
     let PartialHandlers parts =
             setHandlersIgnore <> -- least important
             setHandlersDefinition <> setHandlersHover <>
-            setHandlersCodeAction <> setHandlersCodeLens <> -- useful features someone may override
             setHandlersOutline <>
             userHandlers <>
             setHandlersNotifications <> -- absolutely critical, join them with user notifications

--- a/src/Development/IDE/LSP/LanguageServer.hs
+++ b/src/Development/IDE/LSP/LanguageServer.hs
@@ -30,7 +30,6 @@ import Control.Monad.Extra
 
 import Development.IDE.LSP.HoverDefinition
 import Development.IDE.LSP.CodeAction
-import Development.IDE.LSP.Completions
 import Development.IDE.LSP.Notifications
 import Development.IDE.LSP.Outline
 import Development.IDE.Core.Service
@@ -99,7 +98,6 @@ runLanguageServer options userHandlers getIdeState = do
             setHandlersIgnore <> -- least important
             setHandlersDefinition <> setHandlersHover <>
             setHandlersCodeAction <> setHandlersCodeLens <> -- useful features someone may override
-            setHandlersCompletion <>
             setHandlersOutline <>
             userHandlers <>
             setHandlersNotifications <> -- absolutely critical, join them with user notifications

--- a/src/Development/IDE/Plugin/CodeAction.hs
+++ b/src/Development/IDE/Plugin/CodeAction.hs
@@ -6,7 +6,7 @@
 #include "ghc-api-version.h"
 
 -- | Go to the definition of a variable.
-module Development.IDE.LSP.CodeAction
+module Development.IDE.Plugin.CodeAction
     ( setHandlersCodeAction
     , setHandlersCodeLens
     ) where

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 -- Mostly taken from "haskell-ide-engine"
-module Development.IDE.Core.Completions (
+module Development.IDE.Plugin.Completions.Logic (
   CachedCompletions
 , cacheDataProducer
 , WithSnippets(..)
@@ -29,7 +29,7 @@ import DynFlags
 import Language.Haskell.LSP.Types
 import Language.Haskell.LSP.Types.Capabilities
 import qualified Language.Haskell.LSP.VFS as VFS
-import Development.IDE.Core.CompletionsTypes
+import Development.IDE.Plugin.Completions.Types
 import Development.IDE.Spans.Documentation
 import Development.IDE.GHC.Error
 import Development.IDE.Types.Options

--- a/src/Development/IDE/Plugin/Completions/Types.hs
+++ b/src/Development/IDE/Plugin/Completions/Types.hs
@@ -1,5 +1,5 @@
-module Development.IDE.Core.CompletionsTypes (
-  module Development.IDE.Core.CompletionsTypes
+module Development.IDE.Plugin.Completions.Types (
+  module Development.IDE.Plugin.Completions.Types
 ) where
 
 import           Control.DeepSeq


### PR DESCRIPTION
Move the things into Plugin, expose them, and then put them back after. Aim is to migrate them to haskell/ide/plugin as two separate plugins.

Note this will require the DAML compiler to use these plugins.