### PR TITLE
Provide hie.yaml templates for stack and cabal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ dist/
 .stack-work/
 dist-newstyle/
 cabal.project.local
+hie.yaml
 *~
 *.lock

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,1 +1,0 @@
-cradle: {stack: {component: "ghcide:lib"}}

--- a/hie.yaml.cbl
+++ b/hie.yaml.cbl
@@ -1,0 +1,15 @@
+# This is a sample hie.yaml file for opening ghcide in
+# ghcide/hie/ide, using cabal as the build system.
+# To use is, copy it to a file called 'hie.yaml'
+
+cradle:
+  cabal:
+
+    - path: "./test"
+      component: "ghcide:ghcide-test"
+
+    - path: "./exe"
+      component: "ghcide:exe:ghcide"
+
+    - path: "./src"
+      component: "lib:ghcide"

--- a/hie.yaml.stack
+++ b/hie.yaml.stack
@@ -1,0 +1,14 @@
+# This is a sample hie.yaml file for opening ghcide in
+# ghcide/hie/ide, using stack as the build system.
+# To use is, copy it to a file called 'hie.yaml'
+
+cradle:
+  stack:
+    - path: "./test"
+      component: "ghcide:ghcide-tests"
+
+    - path: "./exe"
+      component: "ghcide:exe:ghcide"
+
+    - path: "./src"
+      component: "ghcide:lib"


### PR DESCRIPTION
And take hie.yaml out of version control, to be a local developer
preference instead.