### PR TITLE
Simplify fingerprint computations

### DIFF
--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -67,7 +67,7 @@ parseModule
     -> HscEnv
     -> FilePath
     -> Maybe SB.StringBuffer
-    -> IO ([FileDiagnostic], Maybe ParsedModule)
+    -> IO ([FileDiagnostic], Maybe (StringBuffer, ParsedModule))
 parseModule IdeOptions{..} env file =
     fmap (either (, Nothing) (second Just)) .
     -- We need packages since imports fail to resolve otherwise.
@@ -353,7 +353,8 @@ parseFileContents
        => (GHC.ParsedSource -> IdePreprocessedSource)
        -> FilePath  -- ^ the filename (for source locations)
        -> Maybe SB.StringBuffer -- ^ Haskell module source text (full Unicode is supported)
-       -> ExceptT [FileDiagnostic] m ([FileDiagnostic], ParsedModule)
+       -> ExceptT [FileDiagnostic] m ([FileDiagnostic], (SB.StringBuffer, ParsedModule))
+            -- ^ Return the String that was used for parsing (after preprocessing)
 parseFileContents customPreprocessor filename mbContents = do
    (contents, dflags) <- preprocessor filename mbContents
    let loc  = mkRealSrcLoc (mkFastString filename) 1 1
@@ -393,4 +394,4 @@ parseFileContents customPreprocessor filename mbContents = do
                        , pm_annotations = hpm_annotations
                       }
                    warnings = diagFromErrMsgs "parser" dflags warns
-               pure (warnings ++ preproc_warnings, pm)
+               pure (warnings ++ preproc_warnings, (contents, pm))

--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -15,8 +15,6 @@ module Development.IDE.Core.FileStore(
     getSourceFingerprint
     ) where
 
-import Foreign.Ptr
-import Foreign.ForeignPtr
 import Fingerprint
 import           StringBuffer
 import Development.IDE.GHC.Orphans()
@@ -109,9 +107,8 @@ fingerprintSourceRule =
     define $ \FingerprintSource file -> do
       (_, mbContent) <- getFileContents file
       content <- liftIO $ maybe (hGetStringBuffer $ fromNormalizedFilePath file) pure mbContent
-      fingerprint <- liftIO $ fpStringBuffer content
+      fingerprint <- liftIO $ fingerprintFromStringBuffer content
       pure ([], Just fingerprint)
-    where fpStringBuffer (StringBuffer buf len cur) = withForeignPtr buf $ \ptr -> fingerprintData (ptr `plusPtr` cur) len
 
 getModificationTimeRule :: VFSHandle -> Rules ()
 getModificationTimeRule vfs =

--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -107,7 +107,7 @@ fingerprintSourceRule =
     define $ \FingerprintSource file -> do
       (_, mbContent) <- getFileContents file
       content <- liftIO $ maybe (hGetStringBuffer $ fromNormalizedFilePath file) pure mbContent
-      fingerprint <- liftIO $ fingerprintFromStringBuffer content
+      fingerprint <- return $ fingerprintFromStringBuffer content
       pure ([], Just fingerprint)
 
 getModificationTimeRule :: VFSHandle -> Rules ()

--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -11,11 +11,9 @@ module Development.IDE.Core.FileStore(
     fileStoreRules,
     VFSHandle,
     makeVFSHandle,
-    makeLSPVFSHandle,
-    getSourceFingerprint
+    makeLSPVFSHandle
     ) where
 
-import Fingerprint
 import           StringBuffer
 import Development.IDE.GHC.Orphans()
 import Development.IDE.GHC.Util
@@ -88,27 +86,11 @@ makeLSPVFSHandle lspFuncs = VFSHandle
 -- | Get the contents of a file, either dirty (if the buffer is modified) or Nothing to mean use from disk.
 type instance RuleResult GetFileContents = (FileVersion, Maybe StringBuffer)
 
-type instance RuleResult FingerprintSource = Fingerprint
-
 data GetFileContents = GetFileContents
     deriving (Eq, Show, Generic)
 instance Hashable GetFileContents
 instance NFData   GetFileContents
 instance Binary   GetFileContents
-
-data FingerprintSource = FingerprintSource
-    deriving (Eq, Show, Generic)
-instance Hashable FingerprintSource
-instance NFData   FingerprintSource
-instance Binary   FingerprintSource
-
-fingerprintSourceRule :: Rules ()
-fingerprintSourceRule =
-    define $ \FingerprintSource file -> do
-      (_, mbContent) <- getFileContents file
-      content <- liftIO $ maybe (hGetStringBuffer $ fromNormalizedFilePath file) pure mbContent
-      fingerprint <- return $ fingerprintFromStringBuffer content
-      pure ([], Just fingerprint)
 
 getModificationTimeRule :: VFSHandle -> Rules ()
 getModificationTimeRule vfs =
@@ -153,9 +135,6 @@ getModificationTimeRule vfs =
 foreign import ccall "getmodtime" c_getModTime :: CString -> Ptr CTime -> Ptr CLong -> IO Int
 #endif
 
-getSourceFingerprint :: NormalizedFilePath -> Action Fingerprint
-getSourceFingerprint = use_ FingerprintSource
-
 getFileContentsRule :: VFSHandle -> Rules ()
 getFileContentsRule vfs =
     define $ \GetFileContents file -> do
@@ -183,7 +162,6 @@ fileStoreRules vfs = do
     addIdeGlobal vfs
     getModificationTimeRule vfs
     getFileContentsRule vfs
-    fingerprintSourceRule
 
 
 -- | Notify the compiler service that a particular file has been modified.

--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -38,6 +38,7 @@ import qualified Data.Rope.UTF16 as Rope
 import Data.Time
 import qualified System.Directory as Dir
 #else
+import Foreign.Ptr
 import Foreign.C.String
 import Foreign.C.Types
 import Foreign.Marshal (alloca)

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -142,7 +142,9 @@ getParsedModuleRule =
         case res of
             Nothing -> pure (Nothing, (diag, Nothing))
             Just (contents, modu) -> do
-                let mbFingerprint = fingerprintToBS (fingerprintFromStringBuffer contents) <$ optShakeFiles opt
+                mbFingerprint <- if isNothing $ optShakeFiles opt
+                    then pure Nothing
+                    else liftIO $ Just . fingerprintToBS <$> fingerprintFromStringBuffer contents
                 pure (mbFingerprint, (diag, Just modu))
 
 getLocatedImportsRule :: Rules ()

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -36,7 +36,7 @@ import Development.IDE.Spans.Calculate
 import Development.IDE.Import.DependencyInformation
 import Development.IDE.Import.FindImports
 import           Development.IDE.Core.FileExists
-import           Development.IDE.Core.FileStore        (getFileContents, getSourceFingerprint)
+import           Development.IDE.Core.FileStore        (getFileContents)
 import           Development.IDE.Types.Diagnostics
 import Development.IDE.Types.Location
 import Development.IDE.GHC.Util
@@ -138,9 +138,12 @@ getParsedModuleRule =
         (_, contents) <- getFileContents file
         packageState <- hscEnv <$> use_ GhcSession file
         opt <- getIdeOptions
-        r <- liftIO $ parseModule opt packageState (fromNormalizedFilePath file) contents
-        mbFingerprint <- traverse (const $ getSourceFingerprint file) (optShakeFiles opt)
-        pure (fingerprintToBS <$> mbFingerprint, r)
+        (diag, res) <- liftIO $ parseModule opt packageState (fromNormalizedFilePath file) contents
+        case res of
+            Nothing -> pure (Nothing, (diag, Nothing))
+            Just (contents, modu) -> do
+                let mbFingerprint = fingerprintToBS (fingerprintFromStringBuffer contents) <$ optShakeFiles opt
+                pure (mbFingerprint, (diag, Just modu))
 
 getLocatedImportsRule :: Rules ()
 getLocatedImportsRule =

--- a/src/Development/IDE/GHC/Util.hs
+++ b/src/Development/IDE/GHC/Util.hs
@@ -56,6 +56,7 @@ import qualified Data.Text.Encoding.Error as T
 import qualified Data.ByteString          as BS
 import StringBuffer
 import System.FilePath
+import System.IO.Unsafe
 
 import Development.IDE.Types.Location
 
@@ -191,9 +192,9 @@ fingerprintToBS (Fingerprint a b) = BS.unsafeCreate 8 $ \ptr -> do
     pokeElemOff ptr 0 a
     pokeElemOff ptr 1 b
 
--- | Take the 'Fingerprint' of a 'StringBuffer'. Morally pure.
-fingerprintFromStringBuffer :: StringBuffer -> IO Fingerprint
-fingerprintFromStringBuffer (StringBuffer buf len cur) =
+-- | Take the 'Fingerprint' of a 'StringBuffer'.
+fingerprintFromStringBuffer :: StringBuffer -> Fingerprint
+fingerprintFromStringBuffer (StringBuffer buf len cur) = unsafePerformIO $
     withForeignPtr buf $ \ptr -> fingerprintData (ptr `plusPtr` cur) len
 
 

--- a/src/Development/IDE/GHC/Util.hs
+++ b/src/Development/IDE/GHC/Util.hs
@@ -56,7 +56,6 @@ import qualified Data.Text.Encoding.Error as T
 import qualified Data.ByteString          as BS
 import StringBuffer
 import System.FilePath
-import System.IO.Unsafe
 
 import Development.IDE.Types.Location
 
@@ -193,8 +192,8 @@ fingerprintToBS (Fingerprint a b) = BS.unsafeCreate 8 $ \ptr -> do
     pokeElemOff ptr 1 b
 
 -- | Take the 'Fingerprint' of a 'StringBuffer'.
-fingerprintFromStringBuffer :: StringBuffer -> Fingerprint
-fingerprintFromStringBuffer (StringBuffer buf len cur) = unsafePerformIO $
+fingerprintFromStringBuffer :: StringBuffer -> IO Fingerprint
+fingerprintFromStringBuffer (StringBuffer buf len cur) =
     withForeignPtr buf $ \ptr -> fingerprintData (ptr `plusPtr` cur) len
 
 

--- a/src/Development/IDE/GHC/Util.hs
+++ b/src/Development/IDE/GHC/Util.hs
@@ -17,6 +17,8 @@ module Development.IDE.GHC.Util(
     lookupPackageConfig,
     moduleImportPath,
     cgGutsToCoreModule,
+    fingerprintToBS,
+    fingerprintFromStringBuffer,
     -- * General utilities
     textToStringBuffer,
     readFileUtf8,
@@ -28,15 +30,17 @@ import Control.Concurrent
 import Data.List.Extra
 import Data.Maybe
 import Data.Typeable
-#if MIN_GHC_API_VERSION(8,6,0)
+import qualified Data.ByteString.Internal as BS
 import Fingerprint
-#endif
 import GHC
 import GhcMonad
 import GhcPlugins hiding (Unique)
 import Data.IORef
 import Control.Exception
 import FileCleanup
+import Foreign.Ptr
+import Foreign.ForeignPtr
+import Foreign.Storable
 import GHC.IO.BufferedIO (BufferedIO)
 import GHC.IO.Device as IODevice
 import GHC.IO.Encoding
@@ -178,6 +182,20 @@ cgGutsToCoreModule safeMode guts modDetails = CoreModule
     (md_types modDetails)
     (cg_binds guts)
     safeMode
+
+-- | Convert a 'Fingerprint' to a 'ByteString' by copying the byte across.
+--   Will produce an 8 byte unreadable ByteString.
+fingerprintToBS :: Fingerprint -> BS.ByteString
+fingerprintToBS (Fingerprint a b) = BS.unsafeCreate 8 $ \ptr -> do
+    ptr <- pure $ castPtr ptr
+    pokeElemOff ptr 0 a
+    pokeElemOff ptr 1 b
+
+-- | Take the 'Fingerprint' of a 'StringBuffer'. Morally pure.
+fingerprintFromStringBuffer :: StringBuffer -> IO Fingerprint
+fingerprintFromStringBuffer (StringBuffer buf len cur) =
+    withForeignPtr buf $ \ptr -> fingerprintData (ptr `plusPtr` cur) len
+
 
 -- | A slightly modified version of 'hDuplicateTo' from GHC.
 --   Importantly, it avoids the bug listed in https://gitlab.haskell.org/ghc/ghc/merge_requests/2318.


### PR DESCRIPTION
There's no need for them to be a separate rule. Also makes them more efficient by avoiding reading the file twice, and makes them more correct by taking the fingerprint after `#include` files etc.