### PR TITLE
Don't support old haddock-library versions

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -41,7 +41,7 @@ library
         extra,
         fuzzy,
         filepath,
-        haddock-library,
+        haddock-library >= 1.8,
         hashable,
         haskell-lsp-types == 0.19.*,
         haskell-lsp == 0.19.*,

--- a/src/Development/IDE/Spans/Common.hs
+++ b/src/Development/IDE/Spans/Common.hs
@@ -121,13 +121,8 @@ haddockToMarkdown (H.DocExamples es)
       = ">>> " ++ expr ++ "\n" ++ unlines result
 haddockToMarkdown (H.DocHyperlink (H.Hyperlink url Nothing))
   = "<" ++ url ++ ">"
-#if MIN_VERSION_haddock_library(1,8,0)
 haddockToMarkdown (H.DocHyperlink (H.Hyperlink url (Just label)))
   = "[" ++ haddockToMarkdown label ++ "](" ++ url ++ ")"
-#else
-haddockToMarkdown (H.DocHyperlink (H.Hyperlink url (Just label)))
-  = "[" ++ label ++ "](" ++ url ++ ")"
-#endif
 haddockToMarkdown (H.DocPic (H.Picture url Nothing))
   = "![](" ++ url ++ ")"
 haddockToMarkdown (H.DocPic (H.Picture url (Just label)))

--- a/src/Development/IDE/Spans/Common.hs
+++ b/src/Development/IDE/Spans/Common.hs
@@ -82,11 +82,7 @@ spanDocToMarkdown (SpanDocText txt) = txt
 
 spanDocToMarkdownForTest :: String -> String
 spanDocToMarkdownForTest
-#if MIN_VERSION_haddock_library(1,6,0)
   = haddockToMarkdown . H.toRegular . H._doc . H.parseParas Nothing
-#else
-  = haddockToMarkdown . H.toRegular . H._doc . H.parseParas
-#endif
 
 -- Simple (and a bit hacky) conversion from Haddock markup to Markdown
 haddockToMarkdown

--- a/stack-ghc-lib.yaml
+++ b/stack-ghc-lib.yaml
@@ -11,6 +11,7 @@ extra-deps:
 - fuzzy-0.1.0.0
 - regex-base-0.94.0.0
 - regex-tdfa-1.3.1.0
+- haddock-library-1.8.0
 nix:
   packages: [zlib]
 flags:

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,5 +11,6 @@ extra-deps:
 - regex-base-0.94.0.0
 - regex-tdfa-1.3.1.0
 - parser-combinators-1.2.1
+- haddock-library-1.8.0
 nix:
   packages: [zlib]

--- a/stack84.yaml
+++ b/stack84.yaml
@@ -15,6 +15,7 @@ extra-deps:
 - regex-base-0.94.0.0
 - regex-tdfa-1.3.1.0
 - parser-combinators-1.2.1
+- haddock-library-1.8.0
 nix:
   packages: [zlib]
 allow-newer: true

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -1665,11 +1665,7 @@ haddockTests
           (unlines
              [ ""
              , ""
-#if MIN_VERSION_haddock_library(1,8,0)
              , "However,  `(+)`  and  `(*)`  are"
-#else
-             , "However, '(+)' and '(*)' are"
-#endif
              , "customarily expected to define a ring and have the following properties: "
              , "+ ****Associativity of (+)****: `(x + y) + z`  =  `x + (y + z)`"
              , "+ ****Commutativity of (+)****: `x + y`  =  `y + x`"


### PR DESCRIPTION
I don't see any reason for supporting old versions of haddock-library. Might as well just demand the latest everywhere (and see if the CI disagrees with me).