### PR TITLE
Move the definition of __GHCIDE__

### DIFF
--- a/src/Development/IDE/Core/Preprocessor.hs
+++ b/src/Development/IDE/Core/Preprocessor.hs
@@ -167,10 +167,18 @@ runLhs dflags filename contents = withTempDir $ \dir -> do
     escape []        = []
 
 
+modifyOptP :: ([String] -> [String]) -> DynFlags -> DynFlags
+modifyOptP op = onSettings (onOptP op)
+  where
+    onSettings f x = x{settings = f $ settings x}
+    onOptP f x = x{sOpt_P = f $ sOpt_P x}
+
 -- | Run CPP on a file
 runCpp :: DynFlags -> FilePath -> Maybe SB.StringBuffer -> IO SB.StringBuffer
 runCpp dflags filename contents = withTempDir $ \dir -> do
     let out = dir </> takeFileName filename <.> "out"
+    dflags <- pure $ modifyOptP ("-D__GHCIDE__":) dflags
+
     case contents of
         Nothing -> do
             -- Happy case, file is not modified, so run CPP on it in-place

--- a/src/Development/IDE/GHC/CPP.hs
+++ b/src/Development/IDE/GHC/CPP.hs
@@ -116,8 +116,6 @@ doCpp dflags raw input_fn output_fn = do
                     ++ map SysTools.Option sse_defs
                     ++ map SysTools.Option avx_defs
                     ++ mb_macro_include
-        -- Define a special macro "__GHCIDE__"
-                    ++ [ SysTools.Option "-D__GHCIDE__"]
         -- Set the language mode to assembler-with-cpp when preprocessing. This
         -- alleviates some of the C99 macro rules relating to whitespace and the hash
         -- operator, which we tend to abuse. Clang in particular is not very happy


### PR DESCRIPTION
Before it was in upstream code we wanted to reshare. Now it's not. Makes the GHC 8.10 upgrade better. I also added a test.