### PR TITLE
Better progress messages

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -53,7 +53,7 @@ library
         regex-tdfa >= 1.3.1.0,
         rope-utf16-splay,
         safe-exceptions,
-        shake >= 0.17.5,
+        shake >= 0.18.4,
         sorted-list,
         stm,
         syb,

--- a/stack-ghc-lib.yaml
+++ b/stack-ghc-lib.yaml
@@ -9,6 +9,7 @@ extra-deps:
 - ghc-lib-parser-8.8.1
 - ghc-lib-8.8.1
 - fuzzy-0.1.0.0
+- shake-0.18.4
 - regex-base-0.94.0.0
 - regex-tdfa-1.3.1.0
 nix:

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,6 +10,7 @@ extra-deps:
 - regex-pcre-builtin-0.95.1.1.8.43
 - regex-base-0.94.0.0
 - regex-tdfa-1.3.1.0
+- shake-0.18.4
 - parser-combinators-1.2.1
 nix:
   packages: [zlib]

--- a/stack84.yaml
+++ b/stack84.yaml
@@ -7,7 +7,6 @@ extra-deps:
 - haskell-lsp-types-0.19.0.0
 - lsp-test-0.10.0.0
 - rope-utf16-splay-0.3.1.0
-- shake-0.18.3
 - filepattern-0.1.1
 - js-dgtable-0.5.2
 - hie-bios-0.3.2

--- a/stack84.yaml
+++ b/stack84.yaml
@@ -12,6 +12,7 @@ extra-deps:
 - js-dgtable-0.5.2
 - hie-bios-0.3.2
 - fuzzy-0.1.0.0
+- shake-0.18.4
 - regex-base-0.94.0.0
 - regex-tdfa-1.3.1.0
 - parser-combinators-1.2.1


### PR DESCRIPTION
Instead of saying how many nodes are in the Shake graph, we instead say how many files have started in the Shake graph. Unlike the previous measure, it isn't guaranteed to be monotonically increasing, as you might start additional rules after running files. But, in practice it seems pretty good, as we're hooking in somewhere very low level, the numbers "have the right feel" - when I have a project open the number roughly corresponds to the number of files, and roughly feels like the work is checking files. It also has more overhead, but if that's a problem, could be redone in terms of IORef to avoid the Var.

Probably worth someone other than me also playing with it to confirm it "feels right".

Fixes #320