### PR TITLE
Improve performance by caching conversion to NormalizedUri

### DIFF
--- a/src/Development/IDE/Types/Location.hs
+++ b/src/Development/IDE/Types/Location.hs
@@ -58,7 +58,7 @@ import GHC.Generics
 --
 -- This is one of the most performance critical parts of ghcide, do not
 -- modify it without profiling.
-data NormalizedFilePath = NormalizedFilePath NormalizedUriWrapper Int !FilePath
+data NormalizedFilePath = NormalizedFilePath NormalizedUriWrapper !Int !FilePath
     deriving (Generic, Eq, Ord)
 
 instance NFData NormalizedFilePath where

--- a/src/Development/IDE/Types/Location.hs
+++ b/src/Development/IDE/Types/Location.hs
@@ -49,22 +49,55 @@ import Language.Haskell.LSP.Types as LSP (
   )
 import SrcLoc as GHC
 import Text.ParserCombinators.ReadP as ReadP
+import GHC.Generics
 
 
 -- | Newtype wrapper around FilePath that always has normalized slashes.
-newtype NormalizedFilePath = NormalizedFilePath FilePath
-    deriving (Eq, Ord, Show, Hashable, NFData, Binary)
+-- The NormalizedUri and hash of the FilePath are cached to avoided
+-- repeated normalisation when we need to compute them (which is a lot).
+--
+-- This is one of the most performance critical parts of ghcide, do not
+-- modify it without profiling.
+data NormalizedFilePath = NormalizedFilePath NormalizedUriWrapper Int !FilePath
+    deriving (Generic, Eq, Ord)
+
+instance NFData NormalizedFilePath where
+instance Binary NormalizedFilePath where
+  put (NormalizedFilePath _ _ fp) = put fp
+  get = do
+    v <- Data.Binary.get :: Get FilePath
+    return (toNormalizedFilePath v)
+
+
+instance Show NormalizedFilePath where
+  show (NormalizedFilePath _ _ fp) = "NormalizedFilePath " ++ show fp
+
+instance Hashable NormalizedFilePath where
+  hash (NormalizedFilePath _ h _) = h
+
+-- Just to define NFData and Binary
+newtype NormalizedUriWrapper =
+  NormalizedUriWrapper { unwrapNormalizedFilePath :: NormalizedUri }
+  deriving (Show, Generic, Eq, Ord)
+
+instance NFData NormalizedUriWrapper where
+  rnf = rwhnf
+
+
+instance Hashable NormalizedUriWrapper where
 
 instance IsString NormalizedFilePath where
     fromString = toNormalizedFilePath
 
 toNormalizedFilePath :: FilePath -> NormalizedFilePath
 -- We want to keep empty paths instead of normalising them to "."
-toNormalizedFilePath "" = NormalizedFilePath ""
-toNormalizedFilePath fp = NormalizedFilePath $ normalise fp
+toNormalizedFilePath "" = NormalizedFilePath (NormalizedUriWrapper emptyPathUri) (hash ("" :: String)) ""
+toNormalizedFilePath fp =
+  let nfp = normalise fp
+  in NormalizedFilePath (NormalizedUriWrapper $ filePathToUriInternal' nfp) (hash nfp) nfp
 
 fromNormalizedFilePath :: NormalizedFilePath -> FilePath
-fromNormalizedFilePath (NormalizedFilePath fp) = fp
+fromNormalizedFilePath (NormalizedFilePath _ _ fp) = fp
 
 -- | We use an empty string as a filepath when we don’t have a file.
 -- However, haskell-lsp doesn’t support that in uriToFilePath and given
@@ -76,10 +109,13 @@ uriToFilePath' uri
     | otherwise = LSP.uriToFilePath uri
 
 emptyPathUri :: NormalizedUri
-emptyPathUri = filePathToUri' ""
+emptyPathUri = filePathToUriInternal' ""
 
 filePathToUri' :: NormalizedFilePath -> NormalizedUri
-filePathToUri' (NormalizedFilePath fp) = toNormalizedUri $ Uri $ T.pack $ LSP.fileScheme <> "//" <> platformAdjustToUriPath fp
+filePathToUri' (NormalizedFilePath (NormalizedUriWrapper u) _ _) = u
+
+filePathToUriInternal' :: FilePath -> NormalizedUri
+filePathToUriInternal' fp = toNormalizedUri $ Uri $ T.pack $ LSP.fileScheme <> "//" <> platformAdjustToUriPath fp
   where
     -- The definitions below are variants of the corresponding functions in Language.Haskell.LSP.Types.Uri that assume that
     -- the filepath has already been normalised. This is necessary since normalising the filepath has a nontrivial cost.


### PR DESCRIPTION
Two changes in this patch make performance quite a lot better for all actions.

1. Cache the conversion to `NormalizedUri` from `NormalizedFilePath`
2. Use a hash map for the debouncer to take advantage of the fast hash instance of `NormalizedUri`. 

The cached `Hashable` instance is in this PR: https://github.com/alanz/haskell-lsp/pull/214

My benchmark which ran hover 1000 times went down from 259s to 37s including initialisation time. Hovering on large projects is not noticeably faster (1s vs < 0.1s). 

Reviewer: @pepeiborra 

Note: I removed the Eq/Ord instance from Pepe's original patch because they relied on the hash for comparing equality. There are some hotspots on the latest profile from 

![image](https://user-images.githubusercontent.com/1216657/73224306-003f4100-4161-11ea-8199-c3feb84ffa1d.png)

![image](https://user-images.githubusercontent.com/1216657/73224333-1816c500-4161-11ea-8857-ce3de640719d.png)

