### PR TITLE
Only show progress messages if the computation takes > 0.1s

### DIFF
--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -320,6 +320,9 @@ shakeOpen getLspId eventer logger shakeProfileDir (IdeReportProgress reportProgr
 
 lspShakeProgress :: IO LSP.LspId -> (LSP.FromServerMessage -> IO ()) -> IO Progress -> IO ()
 lspShakeProgress getLspId sendMsg prog = do
+    -- first sleep a bit, so we only show progress messages if it's going to take
+    -- a "noticable amount of time"
+    sleep 0.1
     lspId <- getLspId
     u <- ProgressTextToken . T.pack . show . hashUnique <$> newUnique
     sendMsg $ LSP.ReqWorkDoneProgressCreate $ LSP.fmServerWorkDoneProgressCreateRequest


### PR DESCRIPTION
At the moment it flickers a progress bar a lot, which is annoying. I first tried 0.3s but that made it almost never show, which felt wrong. 0.1 seems to have reasonable ergonomics.