### PR TITLE
Allow getting file contents as Text 

### DIFF
--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -14,9 +14,7 @@ module Development.IDE.Core.FileStore(
     makeLSPVFSHandle
     ) where
 
-import           StringBuffer
 import Development.IDE.GHC.Orphans()
-import Development.IDE.GHC.Util
 import           Development.IDE.Core.Shake
 import Control.Concurrent.Extra
 import qualified Data.Map.Strict as Map
@@ -85,7 +83,7 @@ makeLSPVFSHandle lspFuncs = VFSHandle
 
 
 -- | Get the contents of a file, either dirty (if the buffer is modified) or Nothing to mean use from disk.
-type instance RuleResult GetFileContents = (FileVersion, Maybe StringBuffer)
+type instance RuleResult GetFileContents = (FileVersion, Maybe T.Text)
 
 data GetFileContents = GetFileContents
     deriving (Eq, Show, Generic)
@@ -143,7 +141,7 @@ getFileContentsRule vfs =
         time <- use_ GetModificationTime file
         res <- liftIO $ ideTryIOException file $ do
             mbVirtual <- getVirtualFile vfs $ filePathToUri' file
-            pure $ textToStringBuffer . Rope.toText . _text <$> mbVirtual
+            pure $ Rope.toText . _text <$> mbVirtual
         case res of
             Left err -> return ([err], Nothing)
             Right contents -> return ([], Just (time, contents))
@@ -155,7 +153,7 @@ ideTryIOException fp act =
       <$> try act
 
 
-getFileContents :: NormalizedFilePath -> Action (FileVersion, Maybe StringBuffer)
+getFileContents :: NormalizedFilePath -> Action (FileVersion, Maybe T.Text)
 getFileContents = use_ GetFileContents
 
 fileStoreRules :: VFSHandle -> Rules ()

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -138,7 +138,7 @@ getParsedModuleRule =
         (_, contents) <- getFileContents file
         packageState <- hscEnv <$> use_ GhcSession file
         opt <- getIdeOptions
-        (diag, res) <- liftIO $ parseModule opt packageState (fromNormalizedFilePath file) contents
+        (diag, res) <- liftIO $ parseModule opt packageState (fromNormalizedFilePath file) (fmap textToStringBuffer contents)
         case res of
             Nothing -> pure (Nothing, (diag, Nothing))
             Just (contents, modu) -> do


### PR DESCRIPTION
The VFS already provides it as Text, and getFileContents converts it
to a StringBuffer.

Expose the intermediate step so that tools such as formatters can
access it without a double conversion.