### PR TITLE
Require GHC 8.6.5 for some docs tests

### DIFF
--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -1387,7 +1387,7 @@ completionTests
           [complItem "head" (Just CiFunction) (Just "[a] -> a")]
         let [CompletionItem { _documentation = headDocs}] = compls
         checkDocText "head" headDocs [ "Defined in 'Prelude'"
-#if MIN_GHC_API_VERSION(8,6,0)
+#if MIN_GHC_API_VERSION(8,6,5)
                                      , "Extract the first element of a list"
 #endif
                                      ]
@@ -1415,7 +1415,7 @@ completionTests
         let [ CompletionItem { _documentation = boundedDocs},
               CompletionItem { _documentation = boolDocs } ] = compls
         checkDocText "Bounded" boundedDocs [ "Defined in 'Prelude'"
-#if MIN_GHC_API_VERSION(8,6,0)
+#if MIN_GHC_API_VERSION(8,6,5)
                                            , "name the upper and lower limits"
 #endif
                                            ]
@@ -1430,7 +1430,7 @@ completionTests
           [complItem "head" (Just CiFunction) (Just "[a] -> a")]
         let [CompletionItem { _documentation = headDocs}] = compls
         checkDocText "head" headDocs [ "Defined in 'Prelude'"
-#if MIN_GHC_API_VERSION(8,6,0)
+#if MIN_GHC_API_VERSION(8,6,5)
                                      , "Extract the first element of a list"
 #endif
                                      ]


### PR DESCRIPTION
These doc tests fail on GHC 8.6.4, so restrict them to 8.6.5 and above. See https://github.com/haskell/haskell-language-server/issues/22