### PR TITLE
#381, require shake-0.18.5, which ensures progress cancellation is robust

### DIFF
--- a/src/Development/IDE/GHC/CPP.hs
+++ b/src/Development/IDE/GHC/CPP.hs
@@ -29,7 +29,7 @@ import DynFlags
 import Panic
 import FileCleanup
 #if MIN_GHC_API_VERSION(8,8,2)
-import LlvmCodeGen (LlvmVersion, llvmVersionList)
+import LlvmCodeGen (llvmVersionList)
 #elif MIN_GHC_API_VERSION(8,8,0)
 import LlvmCodeGen (LlvmVersion (..))
 #endif

--- a/stack-ghc-lib.yaml
+++ b/stack-ghc-lib.yaml
@@ -9,7 +9,7 @@ extra-deps:
 - ghc-lib-parser-8.8.1
 - ghc-lib-8.8.1
 - fuzzy-0.1.0.0
-- shake-0.18.4
+- shake-0.18.5
 - regex-base-0.94.0.0
 - regex-tdfa-1.3.1.0
 - haddock-library-1.8.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,7 +10,7 @@ extra-deps:
 - regex-pcre-builtin-0.95.1.1.8.43
 - regex-base-0.94.0.0
 - regex-tdfa-1.3.1.0
-- shake-0.18.4
+- shake-0.18.5
 - parser-combinators-1.2.1
 - haddock-library-1.8.0
 nix:

--- a/stack84.yaml
+++ b/stack84.yaml
@@ -11,7 +11,7 @@ extra-deps:
 - js-dgtable-0.5.2
 - hie-bios-0.3.2
 - fuzzy-0.1.0.0
-- shake-0.18.4
+- shake-0.18.5
 - regex-base-0.94.0.0
 - regex-tdfa-1.3.1.0
 - parser-combinators-1.2.1

--- a/stack88.yaml
+++ b/stack88.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2020-01-21
+resolver: nightly-2020-02-03
 packages:
 - .
 extra-deps:

--- a/stack88.yaml
+++ b/stack88.yaml
@@ -3,6 +3,6 @@ packages:
 - .
 extra-deps:
 - fuzzy-0.1.0.0
-allow-newer: true
+- hie-bios-0.3.2
 nix:
   packages: [zlib]


### PR DESCRIPTION
Now the progress thread gets killed more robustly, so progress messages always stop.