### PR TITLE
Make ghcide on the command line use absolute file paths

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -107,7 +107,9 @@ main = do
         putStrLn "Report bugs at https://github.com/digital-asset/ghcide/issues"
 
         putStrLn $ "\nStep 1/6: Finding files to test in " ++ dir
-        files <- nubOrd <$> expandFiles (argFiles ++ ["." | null argFiles])
+        files <- expandFiles (argFiles ++ ["." | null argFiles])
+        -- LSP works with absolute file paths, so try and behave similarly
+        files <- nubOrd <$> mapM canonicalizePath files
         putStrLn $ "Found " ++ show (length files) ++ " files"
 
         putStrLn "\nStep 2/6: Looking for hie.yaml files that control setup"


### PR DESCRIPTION
Ghcide via LSP uses absolute paths, but via the command line tester uses relative paths. As a consequence the nasty thing I was debugging worked perfectly, so better to make everything work the same if we possibly can.