### PR TITLE
Automatically pick up new dependencies

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -169,14 +169,17 @@ executable ghcide
     build-depends:
         hslogger,
         base == 4.*,
+        binary,
         containers,
         data-default,
+        deepseq,
         directory,
         extra,
         filepath,
         ghc-paths,
         ghc,
         gitrev,
+        hashable,
         haskell-lsp,
         hie-bios >= 0.4.0 && < 0.5,
         ghcide,
@@ -189,6 +192,7 @@ executable ghcide
         Paths_ghcide
 
     default-extensions:
+        DeriveGeneric
         RecordWildCards
         TupleSections
         ViewPatterns

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,1 +1,3 @@
 cradle: {stack: {component: "ghcide:lib"}}
+dependencies:
+  - ghcide.cabal

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,3 +1,1 @@
 cradle: {stack: {component: "ghcide:lib"}}
-dependencies:
-  - ghcide.cabal

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -10,7 +10,7 @@
 --
 module Development.IDE.Core.Rules(
     IdeState, GetDependencies(..), GetParsedModule(..), TransitiveDependencies(..),
-    Priority(..), GhcSessionIO(..), GhcSessionFun(..), GetHscEnvEq(..),
+    Priority(..), GhcSessionIO(..), GhcSessionFun(..), GetHscEnv(..),
     priorityTypeCheck,
     priorityGenerateCore,
     priorityFilesOfInterest,
@@ -335,16 +335,16 @@ instance NFData GhcSessionFun where rnf !_ = ()
 
 
 -- Rule type for caching GHC sessions.
-type instance RuleResult GetHscEnvEq = HscEnvEq
+type instance RuleResult GetHscEnv = HscEnvEq
 
-data GetHscEnvEq = GetHscEnvEq
+data GetHscEnv = GetHscEnv
     { hscenvOptions :: [String]        -- componentOptions from hie-bios
     , hscenvDependencies :: [FilePath] -- componentDependencies from hie-bios
     }
     deriving (Eq, Show, Typeable, Generic)
-instance Hashable GetHscEnvEq
-instance NFData   GetHscEnvEq
-instance Binary   GetHscEnvEq
+instance Hashable GetHscEnv
+instance NFData   GetHscEnv
+instance Binary   GetHscEnv
 
 
 loadGhcSession :: Rules ()

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -64,6 +64,7 @@ main = defaultMain $ testGroup "HIE"
   , haddockTests
   , positionMappingTests
   , watchedFilesTests
+  , sessionDepsArePickedUp
   ]
 
 initializeResponseTests :: TestTree
@@ -1774,12 +1775,76 @@ haddockTests
   where
     checkHaddock s txt = spanDocToMarkdownForTest s @?= txt
 
+
+sessionDepsArePickedUp :: TestTree
+sessionDepsArePickedUp = testSession'
+  "session-deps-are-picked-up"
+  $ \dir -> do
+    liftIO $ do
+      writeFileUTF8 (dir </> "hie.yaml") "cradle: {stack: {component: \"foo:lib\"}}"
+      writeFileUTF8 (dir </> "stack.yaml") stackYamlContent
+      writeFileUTF8 (dir </> "package.yaml") oldPackageYamlContent
+    -- Open without OverloadedStrings and expect an error.
+    doc <- openDoc' "Foo.hs" "haskell" fooContent
+    expectDiagnostics
+      [("Foo.hs", [(DsError, (3, 6), "Couldn't match expected type")])]
+    -- Update package.yaml to enable OverloadedStrings.
+    liftIO $ writeFileUTF8 (dir </> "package.yaml") newPackageYamlContent
+    -- Send change event.
+    let change =
+          TextDocumentContentChangeEvent
+            { _range = Just (Range (Position 5 0) (Position 5 0)),
+              _rangeLength = Nothing,
+              _text = "\n"
+            }
+    changeDoc doc [change]
+    -- Now no errors.
+    expectDiagnostics [("Foo.hs", [])]
+  where
+    stackYamlContent =
+      unlines
+        [ "resolver: nightly-2019-09-21",
+          "packages:",
+          "  - ."
+        ]
+    oldPackageYamlContent =
+      unlines
+        [ "name: foo",
+          "library:",
+          "  source-dirs:",
+          "    - .",
+          "dependencies:",
+          "  - base"
+        ]
+    newPackageYamlContent =
+      unlines
+        [ "name: foo",
+          "library:",
+          "  source-dirs:",
+          "    - .",
+          "dependencies:",
+          "  - base",
+          "default-extensions:",
+          "  - OverloadedStrings"
+        ]
+    fooContent =
+      T.unlines
+        [ "module Foo where",
+          "import Data.Text",
+          "foo :: Text",
+          "foo = \"hello\""
+        ]
+
+
 ----------------------------------------------------------------------
 -- Utils
 
 
 testSession :: String -> Session () -> TestTree
 testSession name = testCase name . run
+
+testSession' :: String -> (FilePath -> Session ()) -> TestTree
+testSession' name = testCase name . run'
 
 testSessionWait :: String -> Session () -> TestTree
 testSessionWait name = testSession name .
@@ -1801,7 +1866,13 @@ mkRange :: Int -> Int -> Int -> Int -> Range
 mkRange a b c d = Range (Position a b) (Position c d)
 
 run :: Session a -> IO a
-run s = withTempDir $ \dir -> do
+run s = withTempDir $ \dir -> runInDir dir s
+
+run' :: (FilePath -> Session a) -> IO a
+run' s = withTempDir $ \dir -> runInDir dir (s dir)
+
+runInDir :: FilePath -> Session a -> IO a
+runInDir dir s = do
   ghcideExe <- locateGhcideExecutable
 
   -- Temporarily hack around https://github.com/mpickering/hie-bios/pull/56


### PR DESCRIPTION
hie-bios's componentDependencies returns the dependencies of a cradle
that might change the cradle. Add those deps to the shake graph so that
the GHC session is newly created whenever they change.

For that, add a new rule type, GetHscEnvEq, to cache GHC sessions with
the key of GHC options and dependencies. And delete the optGhcSession
field from IdeOptions.

This is for https://github.com/digital-asset/ghcide/issues/50.

hie-bios's componentDependencies can return files that don't exist yet:
https://github.com/mpickering/hie-bios/blob/master/src/HIE/Bios/Types.hs#L90-L93.
This PR handles changes in the existing dependency files, but doesn't
handle newly created dependency files.