### PR TITLE
Workspace roots and getFileExists

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -101,6 +101,7 @@ library
     exposed-modules:
         Development.IDE.Core.Debouncer
         Development.IDE.Core.FileStore
+        Development.IDE.Core.IdeConfiguration
         Development.IDE.Core.OfInterest
         Development.IDE.Core.PositionMapping
         Development.IDE.Core.Rules

--- a/src/Development/IDE/Core/IdeConfiguration.hs
+++ b/src/Development/IDE/Core/IdeConfiguration.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+module Development.IDE.Core.IdeConfiguration
+  ( IdeConfiguration(..)
+  , registerIdeConfiguration
+  , parseConfiguration
+  , parseWorkspaceFolder
+  , isWorkspaceFile
+  , modifyWorkspaceFolders
+  )
+where
+
+import           Control.Concurrent.Extra
+import           Control.Monad
+import           Data.HashSet                   (HashSet, singleton)
+import           Data.Text                      (Text, isPrefixOf)
+import           Development.IDE.Core.Shake
+import           Development.IDE.Types.Location
+import           Development.Shake
+import           Language.Haskell.LSP.Types
+
+-- | Lsp client relevant configuration details
+data IdeConfiguration = IdeConfiguration
+  { workspaceFolders :: HashSet NormalizedUri
+  }
+  deriving (Show)
+
+data IdeConfigurationVar = IdeConfigurationVar {unIdeConfigurationRef :: Var IdeConfiguration}
+
+instance IsIdeGlobal IdeConfigurationVar
+
+registerIdeConfiguration :: ShakeExtras -> IdeConfiguration -> IO ()
+registerIdeConfiguration extras =
+  addIdeGlobalExtras extras . IdeConfigurationVar <=< newVar
+
+getIdeConfiguration :: Action IdeConfiguration
+getIdeConfiguration =
+  getIdeGlobalAction >>= liftIO . readVar . unIdeConfigurationRef
+
+parseConfiguration :: InitializeRequest -> IdeConfiguration
+parseConfiguration RequestMessage { _params = InitializeParams {..} } =
+  IdeConfiguration { .. }
+ where
+  workspaceFolders =
+    foldMap (singleton . toNormalizedUri) _rootUri
+      <> (foldMap . foldMap)
+           (singleton . parseWorkspaceFolder)
+           _workspaceFolders
+
+parseWorkspaceFolder :: WorkspaceFolder -> NormalizedUri
+parseWorkspaceFolder =
+  toNormalizedUri . Uri . (_uri :: WorkspaceFolder -> Text)
+
+modifyWorkspaceFolders
+  :: IdeState -> (HashSet NormalizedUri -> HashSet NormalizedUri) -> IO ()
+modifyWorkspaceFolders ide f = do
+  IdeConfigurationVar var <- getIdeGlobalState ide
+  IdeConfiguration    ws  <- readVar var
+  writeVar var (IdeConfiguration (f ws))
+
+isWorkspaceFile :: NormalizedFilePath -> Action Bool
+isWorkspaceFile file = do
+  IdeConfiguration {..} <- getIdeConfiguration
+  let toText = getUri . fromNormalizedUri
+  return $ any
+    (\root -> toText root `isPrefixOf` toText (filePathToUri' file))
+    workspaceFolders

--- a/src/Development/IDE/Core/IdeConfiguration.hs
+++ b/src/Development/IDE/Core/IdeConfiguration.hs
@@ -24,7 +24,7 @@ data IdeConfiguration = IdeConfiguration
   }
   deriving (Show)
 
-data IdeConfigurationVar = IdeConfigurationVar {unIdeConfigurationRef :: Var IdeConfiguration}
+newtype IdeConfigurationVar = IdeConfigurationVar {unIdeConfigurationRef :: Var IdeConfiguration}
 
 instance IsIdeGlobal IdeConfigurationVar
 

--- a/src/Development/IDE/LSP/Notifications.hs
+++ b/src/Development/IDE/LSP/Notifications.hs
@@ -72,7 +72,9 @@ setHandlersNotifications = PartialHandlers $ \WithMessage{..} x -> return x
             setSomethingModified ide
     ,LSP.didChangeWorkspaceFoldersNotificationHandler = withNotification (LSP.didChangeWorkspaceFoldersNotificationHandler x) $
         \_ ide (DidChangeWorkspaceFoldersParams events) -> do
+            let add       = S.union
+                substract = flip S.difference
             modifyWorkspaceFolders ide
-              $ S.union      (foldMap (S.singleton . parseWorkspaceFolder) (_added   events))
-              . S.difference (foldMap (S.singleton . parseWorkspaceFolder) (_removed events))
+              $ add       (foldMap (S.singleton . parseWorkspaceFolder) (_added   events))
+              . substract (foldMap (S.singleton . parseWorkspaceFolder) (_removed events))
     }

--- a/src/Development/IDE/LSP/Notifications.hs
+++ b/src/Development/IDE/LSP/Notifications.hs
@@ -13,6 +13,7 @@ import qualified Language.Haskell.LSP.Core        as LSP
 import           Language.Haskell.LSP.Types
 import qualified Language.Haskell.LSP.Types       as LSP
 
+import           Development.IDE.Core.IdeConfiguration
 import           Development.IDE.Core.Service
 import           Development.IDE.Types.Location
 import           Development.IDE.Types.Logger
@@ -69,4 +70,9 @@ setHandlersNotifications = PartialHandlers $ \WithMessage{..} x -> return x
             logInfo (ideLogger ide) $ "Files created or deleted: " <> msg
             modifyFileExists ide events
             setSomethingModified ide
+    ,LSP.didChangeWorkspaceFoldersNotificationHandler = withNotification (LSP.didChangeWorkspaceFoldersNotificationHandler x) $
+        \_ ide (DidChangeWorkspaceFoldersParams events) -> do
+            modifyWorkspaceFolders ide
+              $ S.union      (foldMap (S.singleton . parseWorkspaceFolder) (_added   events))
+              . S.difference (foldMap (S.singleton . parseWorkspaceFolder) (_removed events))
     }

--- a/src/Development/IDE/LSP/Outline.hs
+++ b/src/Development/IDE/LSP/Outline.hs
@@ -18,6 +18,7 @@ import           Data.Text                      ( Text
                                                 )
 import qualified Data.Text                     as T
 import           Development.IDE.Core.Rules
+import           Development.IDE.Core.IdeConfiguration
 import           Development.IDE.Core.Shake
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Error      ( srcSpanToRange )
@@ -34,7 +35,7 @@ setHandlersOutline = PartialHandlers $ \WithMessage {..} x -> return x
   }
 
 moduleOutline
-  :: LSP.LspFuncs () -> IdeState -> DocumentSymbolParams -> IO (Either ResponseError DSResult)
+  :: LSP.LspFuncs IdeConfiguration -> IdeState -> DocumentSymbolParams -> IO (Either ResponseError DSResult)
 moduleOutline _lsp ideState DocumentSymbolParams { _textDocument = TextDocumentIdentifier uri }
   = case uriToFilePath uri of
     Just (toNormalizedFilePath -> fp) -> do

--- a/src/Development/IDE/LSP/Server.hs
+++ b/src/Development/IDE/LSP/Server.hs
@@ -14,22 +14,23 @@ import Data.Default
 import           Language.Haskell.LSP.Types
 import qualified Language.Haskell.LSP.Core as LSP
 import qualified Language.Haskell.LSP.Messages as LSP
+import Development.IDE.Core.IdeConfiguration
 import Development.IDE.Core.Service
 
 data WithMessage = WithMessage
     {withResponse :: forall m req resp . (Show m, Show req) =>
         (ResponseMessage resp -> LSP.FromServerMessage) -> -- how to wrap a response
-        (LSP.LspFuncs () -> IdeState -> req -> IO (Either ResponseError resp)) -> -- actual work
+        (LSP.LspFuncs IdeConfiguration -> IdeState -> req -> IO (Either ResponseError resp)) -> -- actual work
         Maybe (LSP.Handler (RequestMessage m req resp))
     ,withNotification :: forall m req . (Show m, Show req) =>
         Maybe (LSP.Handler (NotificationMessage m req)) -> -- old notification handler
-        (LSP.LspFuncs () -> IdeState -> req -> IO ()) -> -- actual work
+        (LSP.LspFuncs IdeConfiguration -> IdeState -> req -> IO ()) -> -- actual work
         Maybe (LSP.Handler (NotificationMessage m req))
     ,withResponseAndRequest :: forall m rm req resp newReqParams newReqBody.
         (Show m, Show rm, Show req, Show newReqParams, Show newReqBody) =>
         (ResponseMessage resp -> LSP.FromServerMessage) -> -- how to wrap a response
         (RequestMessage rm newReqParams newReqBody -> LSP.FromServerMessage) -> -- how to wrap the additional req
-        (LSP.LspFuncs () -> IdeState -> req -> IO (resp, Maybe (rm, newReqParams))) -> -- actual work
+        (LSP.LspFuncs IdeConfiguration -> IdeState -> req -> IO (resp, Maybe (rm, newReqParams))) -> -- actual work
         Maybe (LSP.Handler (RequestMessage m req resp))
     }
 

--- a/src/Development/IDE/Plugin.hs
+++ b/src/Development/IDE/Plugin.hs
@@ -7,6 +7,7 @@ import Development.IDE.LSP.Server
 
 import           Language.Haskell.LSP.Types
 import Development.IDE.Core.Rules
+import           Development.IDE.Core.IdeConfiguration
 import qualified Language.Haskell.LSP.Core as LSP
 import Language.Haskell.LSP.Messages
 
@@ -26,7 +27,7 @@ instance Monoid Plugin where
     mempty = def
 
 
-codeActionPlugin :: (LSP.LspFuncs () -> IdeState -> TextDocumentIdentifier -> Range -> CodeActionContext -> IO (Either ResponseError [CAResult])) -> Plugin
+codeActionPlugin :: (LSP.LspFuncs IdeConfiguration -> IdeState -> TextDocumentIdentifier -> Range -> CodeActionContext -> IO (Either ResponseError [CAResult])) -> Plugin
 codeActionPlugin f = Plugin mempty $ PartialHandlers $ \WithMessage{..} x -> return x{
     LSP.codeActionHandler = withResponse RspCodeAction g
     }

--- a/src/Development/IDE/Plugin/CodeAction.hs
+++ b/src/Development/IDE/Plugin/CodeAction.hs
@@ -12,6 +12,7 @@ import           Language.Haskell.LSP.Types
 import Control.Monad (join)
 import Development.IDE.Plugin
 import Development.IDE.GHC.Compat
+import Development.IDE.Core.IdeConfiguration
 import Development.IDE.Core.Rules
 import Development.IDE.Core.RuleTypes
 import Development.IDE.Core.Service
@@ -43,7 +44,7 @@ plugin = codeActionPlugin codeAction <> Plugin mempty setHandlersCodeLens
 
 -- | Generate code actions.
 codeAction
-    :: LSP.LspFuncs ()
+    :: LSP.LspFuncs IdeConfiguration
     -> IdeState
     -> TextDocumentIdentifier
     -> Range
@@ -65,7 +66,7 @@ codeAction lsp state (TextDocumentIdentifier uri) _range CodeActionContext{_diag
 
 -- | Generate code lenses.
 codeLens
-    :: LSP.LspFuncs ()
+    :: LSP.LspFuncs IdeConfiguration
     -> IdeState
     -> CodeLensParams
     -> IO (Either ResponseError (List CodeLens))
@@ -86,7 +87,7 @@ codeLens _lsp ideState CodeLensParams{_textDocument=TextDocumentIdentifier uri} 
 
 -- | Execute the "typesignature.add" command.
 executeAddSignatureCommand
-    :: LSP.LspFuncs ()
+    :: LSP.LspFuncs IdeConfiguration
     -> IdeState
     -> ExecuteCommandParams
     -> IO (Value, Maybe (ServerMethod, ApplyWorkspaceEditParams))

--- a/src/Development/IDE/Plugin/Completions.hs
+++ b/src/Development/IDE/Plugin/Completions.hs
@@ -17,6 +17,7 @@ import Development.IDE.Plugin
 import Development.IDE.Core.Service
 import Development.IDE.Plugin.Completions.Logic
 import Development.IDE.Types.Location
+import Development.IDE.Core.IdeConfiguration
 import Development.IDE.Core.PositionMapping
 import Development.IDE.Core.RuleTypes
 import Development.IDE.Core.Shake
@@ -55,7 +56,7 @@ instance Binary   ProduceCompletions
 
 -- | Generate code actions.
 getCompletionsLSP
-    :: LSP.LspFuncs ()
+    :: LSP.LspFuncs IdeConfiguration
     -> IdeState
     -> CompletionParams
     -> IO (Either ResponseError CompletionResponseResult)

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -99,7 +99,7 @@ initializeResponseTests = withResource acquire release tests where
     , chk "NO color"                         _colorProvider (Just $ ColorOptionsStatic False)
     , chk "NO folding range"          _foldingRangeProvider (Just $ FoldingRangeOptionsStatic False)
     , chk "   execute command"      _executeCommandProvider (Just $ ExecuteCommandOptions $ List ["typesignature.add"])
-    , chk "NO workspace"                         _workspace  nothingWorkspace
+    , chk "   workspace"                         _workspace (Just $ WorkspaceOptions (Just WorkspaceFolderOptions{_supported = Just True, _changeNotifications = Just ( WorkspaceFolderChangeNotificationsBool True )}))
     , chk "NO experimental"                   _experimental  Nothing
     ] where
 
@@ -109,8 +109,6 @@ initializeResponseTests = withResource acquire release tests where
                               , _willSave  = Nothing
                               , _willSaveWaitUntil = Nothing
                               , _save = Just (SaveOptions {_includeText = Nothing})}))
-
-      nothingWorkspace = Just (WorkspaceOptions {_workspaceFolders = Nothing})
 
       chk :: (Eq a, Show a) => TestName -> (InitializeResponseCapabilitiesInner -> a) -> a -> TestTree
       chk title getActual expected =


### PR DESCRIPTION
This is a correctness fix for `getFileExists` when targetting files out of the workspace - they cannot be watched by the client so we need to fall back to the slow path.

This is a spinout from the effort to switch to interface files (#355).