### PR TITLE
Change the representation of filestamps

### DIFF
--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -95,11 +95,12 @@ getModificationTimeRule :: VFSHandle -> Rules ()
 getModificationTimeRule vfs =
     defineEarlyCutoff $ \GetModificationTime file -> do
         let file' = fromNormalizedFilePath file
-        let wrap time = (Just time, ([], Just $ ModificationTime time))
+        let wrap time@(l,s) = (Just $ BS.pack $ show time, ([], Just $ ModificationTime l s))
         alwaysRerun
         mbVirtual <- liftIO $ getVirtualFile vfs $ filePathToUri' file
         case mbVirtual of
-            Just (virtualFileVersion -> ver) -> pure (Just $ BS.pack $ show ver, ([], Just $ VFSVersion ver))
+            Just (virtualFileVersion -> ver) ->
+                pure (Just $ BS.pack $ show ver, ([], Just $ VFSVersion ver))
             Nothing -> liftIO $ fmap wrap (getModTime file')
               `catch` \(e :: IOException) -> do
                 let err | isDoesNotExistError e = "File does not exist: " ++ file'
@@ -115,11 +116,13 @@ getModificationTimeRule vfs =
     -- We might also want to try speeding this up on Windows at some point.
     -- TODO leverage DidChangeWatchedFile lsp notifications on clients that
     -- support them, as done for GetFileExists
-    getModTime :: FilePath -> IO BS.ByteString
+    getModTime :: FilePath -> IO (Int,Int)
     getModTime f =
 #ifdef mingw32_HOST_OS
         do time <- Dir.getModificationTime f
-           pure $! BS.pack $ show (toModifiedJulianDay $ utctDay time, diffTimeToPicoseconds $ utctDayTime time)
+           let !day = toModifiedJulianDay $ utctDay time
+               !dayTime = diffTimeToPicoseconds $ utctDayTime time
+           pure $! (day, dayTime)
 #else
         withCString f $ \f' ->
         alloca $ \secPtr ->
@@ -127,7 +130,7 @@ getModificationTimeRule vfs =
             Posix.throwErrnoPathIfMinus1Retry_ "getmodtime" f $ c_getModTime f' secPtr nsecPtr
             sec <- peek secPtr
             nsec <- peek nsecPtr
-            pure $! BS.pack $ show sec <> "." <> show nsec
+            pure (fromEnum sec, fromIntegral nsec)
 
 -- Sadly even unix’s getFileStatus + modificationTimeHiRes is still about twice as slow
 -- as doing the FFI call ourselves :(.

--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -122,7 +122,7 @@ getModificationTimeRule vfs =
         do time <- Dir.getModificationTime f
            let !day = toModifiedJulianDay $ utctDay time
                !dayTime = diffTimeToPicoseconds $ utctDayTime time
-           pure $! (day, dayTime)
+           pure (day, dayTime)
 #else
         withCString f $ \f' ->
         alloca $ \secPtr ->

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -36,7 +36,7 @@ module Development.IDE.Core.Shake(
     sendEvent,
     ideLogger,
     actionLogger,
-    FileVersion(..),
+    FileVersion(..), modificationTime,
     Priority(..),
     updatePositionMapping,
     deleteValue,
@@ -763,19 +763,22 @@ instance Binary   GetModificationTime
 -- | Get the modification time of a file.
 type instance RuleResult GetModificationTime = FileVersion
 
--- | We store the modification time as a ByteString since we need
--- a ByteString anyway for Shake and we do not care about how times
--- are represented.
-data FileVersion = VFSVersion Int | ModificationTime BS.ByteString
+data FileVersion
+    = VFSVersion Int
+    | ModificationTime
+      !Int   -- ^ Large unit (platform dependent, do not make assumptions)
+      !Int   -- ^ Small unit (platform dependent, do not make assumptions)
     deriving (Show, Generic)
 
 instance NFData FileVersion
 
 vfsVersion :: FileVersion -> Maybe Int
 vfsVersion (VFSVersion i) = Just i
-vfsVersion (ModificationTime _) = Nothing
+vfsVersion ModificationTime{} = Nothing
 
-
+modificationTime :: FileVersion -> Maybe (Int, Int)
+modificationTime VFSVersion{} = Nothing
+modificationTime (ModificationTime large small) = Just (large, small)
 
 getDiagnosticsFromStore :: StoreItem -> [Diagnostic]
 getDiagnosticsFromStore (StoreItem _ diags) = concatMap SL.fromSortedList $ Map.elems diags


### PR DESCRIPTION
This is needed to be able to compare them, which we need for loading `.hie` and `.hi` files.
Another spinout from the effort to switch to interface files (#355)