### PR TITLE
Use HashMap/HashSet for maps indexed by Normalized{FilePath,Uri}

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -46,7 +46,7 @@ import System.Exit
 import Paths_ghcide
 import Development.GitRev
 import Development.Shake (Action, action)
-import qualified Data.Set as Set
+import qualified Data.HashSet as HashSet
 import qualified Data.Map.Strict as Map
 
 import GHC hiding (def)
@@ -141,7 +141,7 @@ main = do
         ide <- initialise def mainRule (pure $ IdInt 0) (showEvent lock) (logger Info) noopDebouncer options vfs
 
         putStrLn "\nStep 6/6: Type checking the files"
-        setFilesOfInterest ide $ Set.fromList $ map toNormalizedFilePath files
+        setFilesOfInterest ide $ HashSet.fromList $ map toNormalizedFilePath files
         results <- runActionSync ide $ uses TypeCheck $ map toNormalizedFilePath files
         let (worked, failed) = partition fst $ zip (map isJust results) files
         when (failed /= []) $
@@ -169,7 +169,7 @@ expandFiles = concatMapM $ \x -> do
 kick :: Action ()
 kick = do
     files <- getFilesOfInterest
-    void $ uses TypeCheck $ Set.toList files
+    void $ uses TypeCheck $ HashSet.toList files
 
 -- | Print an LSP event.
 showEvent :: Lock -> FromServerMessage -> IO ()

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -60,7 +60,7 @@ library
         text,
         time,
         transformers,
-        unordered-containers,
+        unordered-containers >= 0.2.10.0,
         utf8-string,
         hslogger
     if flag(ghc-lib)
@@ -144,7 +144,7 @@ library
 executable ghcide-test-preprocessor
     default-language: Haskell2010
     hs-source-dirs: test/preprocessor
-    ghc-options: -Wall
+    ghc-options: -Wall -Wno-name-shadowing
     main-is: Main.hs
     build-depends:
         base == 4.*
@@ -181,7 +181,8 @@ executable ghcide
         ghcide,
         optparse-applicative,
         shake,
-        text
+        text,
+        unordered-containers
     other-modules:
         Arguments
         Paths_ghcide

--- a/src/Development/IDE/LSP/Notifications.hs
+++ b/src/Development/IDE/LSP/Notifications.hs
@@ -20,7 +20,7 @@ import           Development.IDE.Types.Logger
 import           Control.Monad.Extra
 import           Data.Foldable                    as F
 import           Data.Maybe
-import qualified Data.Set                         as S
+import qualified Data.HashSet                     as S
 import qualified Data.Text                        as Text
 
 import           Development.IDE.Core.FileStore   (setSomethingModified)

--- a/stack84.yaml
+++ b/stack84.yaml
@@ -19,6 +19,7 @@ extra-deps:
 - regex-tdfa-1.3.1.0
 - parser-combinators-1.2.1
 - haddock-library-1.8.0
+- unordered-containers-0.2.10.0
 nix:
   packages: [zlib]
 allow-newer: true


### PR DESCRIPTION
Now that we have optimized Hashable instances for these, it makes
sense to use this consistently.