### PR TITLE
Code action to suggest adding missing imports from pkg db

### DIFF
--- a/src/Development/IDE/Plugin/CodeAction.hs
+++ b/src/Development/IDE/Plugin/CodeAction.hs
@@ -358,6 +358,9 @@ suggestNewImport eps ParsedModule {pm_parsed_source = L _ HsModule {..}} Diagnos
           RealSrcLoc s -> Just $ srcLocLine s
           _ -> Nothing
   , insertPos <- Position insertLine 0
+  , extendImportSuggestions <- -- Just [binding, mod, srcspan] <-
+    matchRegex _message
+    "Perhaps you want to add ‘[^’]*’ to the import list in the import of ‘([^’]*)’"
   =
     nubOrdBy
       (compare `on` fst)
@@ -369,11 +372,9 @@ suggestNewImport eps ParsedModule {pm_parsed_source = L _ HsModule {..}} Diagnos
           candidate <- availNames avail,
           occNameString (nameOccName candidate) == T.unpack name,
           Just m <- [nameModule_maybe candidate],
-          let edit =
-                "import " <> T.pack (moduleNameString $ moduleName m)
-                  <> " ("
-                  <> T.pack (prettyPrint candidate)
-                  <> ")"
+          let modName = T.pack $ moduleNameString $ moduleName m,
+          modName `notElem` fromMaybe [] extendImportSuggestions,
+          let edit = "import " <> modName <> " (" <> T.pack (prettyPrint candidate) <> ")"
       ]
 suggestNewImport _ _ _ = []
 

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -411,6 +411,7 @@ codeActionTests = testGroup "code actions"
   , typeWildCardActionTests
   , removeImportTests
   , extendImportTests
+  , suggestImportTests
   , addExtensionTests
   , fixConstructorImportTests
   , importRenameActionTests
@@ -865,6 +866,38 @@ extendImportTests = testGroup "extend import actions"
       executeCodeAction action
       contentAfterAction <- documentContents docB
       liftIO $ expectedContentB @=? contentAfterAction
+
+suggestImportTests :: TestTree
+suggestImportTests = testGroup "suggest import actions"
+  [ testGroup "Dont want suggestion"
+    [ test False ["Data.List.NonEmpty ()"] "f = nonEmpty" "import Data.List.NonEmpty (nonEmpty)"
+    ]
+  , testGroup "want suggestion"
+    [ test True [] "f = nonEmpty" "import Data.List.NonEmpty (nonEmpty)"
+    , test True ["Prelude"] "f = nonEmpty" "import Data.List.NonEmpty (nonEmpty)"
+    ]
+  ]
+  where
+    test wanted imps def newImp = testSession (T.unpack def) $ do
+      let before = T.unlines $ "module A where" : ["import " <> x | x <- imps] ++ [def]
+          after  = T.unlines $ "module A where" : ["import " <> x | x <- imps] ++ [newImp, def]
+      doc <- openDoc' "Test.hs" "haskell" before
+      -- load another module in the session to exercise the package cache
+      _   <- openDoc' "Other.hs" "haskell" after
+      _diags <- waitForDiagnostics
+      liftIO $ print _diags
+      let defLine = length imps + 1
+          range = Range (Position defLine 0) (Position defLine maxBound)
+      actions <- getCodeActions doc range
+      case wanted of
+        False ->
+          liftIO $ [_title | CACodeAction CodeAction{_title} <- actions, _title == newImp ] @?= []
+        True -> do
+          liftIO $ print [_title | CACodeAction CodeAction{_title} <- actions]
+          let action = pickActionWithTitle newImp actions
+          executeCodeAction action
+          contentAfterAction <- documentContents doc
+          liftIO $ after @=? contentAfterAction
 
 addExtensionTests :: TestTree
 addExtensionTests = testGroup "add language extension actions"
@@ -1840,7 +1873,7 @@ findCodeActions doc range expectedTitles = do
             [ actionTitle
             | CACodeAction CodeAction { _title = actionTitle } <- actions
             ]
-            ++ "is not a superset of "
+            ++ " is not a superset of "
             ++ show expectedTitles
   liftIO $ case matches of
     Nothing -> assertFailure msg


### PR DESCRIPTION
The implementation looks in modules loaded from the package database. It should
only look in packages declared as dependencies of the project. The package
modules are loaded lazily and are global to the HscEnv, so the success rate will
depend on what has been loaded so far in the env.

I intended to make this as a standalone plugin but we cannot have two plugins providing code actions, see https://github.com/haskell/haskell-language-server/issues/25#issuecomment-586704493