### PR TITLE
Add .hie files support for home modules

### DIFF
--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -24,7 +24,6 @@ import           GHC.Generics                             (Generic)
 import           GHC
 import Module (InstalledUnitId)
 import HscTypes (CgGuts, Linkable, HomeModInfo, ModDetails)
-import Development.IDE.GHC.Compat
 
 import           Development.IDE.Spans.Type
 import           Development.IDE.Import.FindImports (ArtifactsLocation)
@@ -81,10 +80,6 @@ type instance RuleResult GetLocatedImports = ([(Located ModuleName, Maybe Artifa
 -- We cannot report the cycles directly from GetDependencyInformation since
 -- we can only report diagnostics for the current file.
 type instance RuleResult ReportImportCycles = ()
-
--- | Read the given HIE file.
-type instance RuleResult GetHieFile = HieFile
-
 
 data GetParsedModule = GetParsedModule
     deriving (Eq, Show, Typeable, Generic)
@@ -145,11 +140,3 @@ data GhcSession = GhcSession
 instance Hashable GhcSession
 instance NFData   GhcSession
 instance Binary   GhcSession
-
--- Note that we embed the filepath here instead of using the filepath associated with Shake keys.
--- Otherwise we will garbage collect the result since files in package dependencies will not be declared reachable.
-data GetHieFile = GetHieFile FilePath
-    deriving (Eq, Show, Typeable, Generic)
-instance Hashable GetHieFile
-instance NFData   GetHieFile
-instance Binary   GetHieFile

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -29,7 +29,7 @@ import Fingerprint
 
 import Data.Binary
 import Data.Bifunctor (second)
-import Control.Monad
+import Control.Monad.Extra
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Maybe
 import Development.IDE.Core.Compile
@@ -50,6 +50,7 @@ import           Data.Foldable
 import qualified Data.IntMap.Strict as IntMap
 import qualified Data.IntSet as IntSet
 import Data.List
+import Data.Ord
 import qualified Data.Set                                 as Set
 import qualified Data.Text                                as T
 import           Development.IDE.GHC.Error
@@ -58,8 +59,6 @@ import Development.IDE.Core.RuleTypes
 import Development.IDE.Spans.Type
 
 import qualified GHC.LanguageExtensions as LangExt
-import           UniqSupply
-import NameCache
 import HscTypes
 import DynFlags (xopt)
 import GHC.Generics(Generic)
@@ -68,6 +67,7 @@ import qualified Development.IDE.Spans.AtPoint as AtPoint
 import Development.IDE.Core.Service
 import Development.IDE.Core.Shake
 import Development.Shake.Classes
+import qualified System.Directory as IO
 
 -- | This is useful for rules to convert rules that can only produce errors or
 -- a result into the more general IdeResult type that supports producing
@@ -112,9 +112,59 @@ getDefinition :: NormalizedFilePath -> Position -> Action (Maybe Location)
 getDefinition file pos = fmap join $ runMaybeT $ do
     opts <- lift getIdeOptions
     spans <- useE GetSpanInfo file
-    pkgState <- hscEnv <$> useE GhcSession file
-    let getHieFile x = useNoFile (GetHieFile x)
-    lift $ AtPoint.gotoDefinition getHieFile opts pkgState (spansExprs spans) pos
+    lift $ AtPoint.gotoDefinition (getHieFile file) opts (spansExprs spans) pos
+
+getHieFile
+  :: NormalizedFilePath -- ^ file we're editing
+  -> Module -- ^ module dep we want info for
+  -> Action (Maybe (HieFile, FilePath)) -- ^ hie stuff for the module
+getHieFile file mod = do
+  TransitiveDependencies {transitiveNamedModuleDeps} <- use_ GetDependencies file
+  case find (\x -> nmdModuleName x == moduleName mod) transitiveNamedModuleDeps of
+    Just NamedModuleDep{nmdFilePath=nfp} -> do
+        let modPath = fromNormalizedFilePath nfp
+        (_diags, hieFile) <- getHomeHieFile nfp
+        return $ (, modPath) <$> hieFile
+    _ -> getPackageHieFile mod file
+
+
+getHomeHieFile :: NormalizedFilePath -> Action ([a], Maybe HieFile)
+getHomeHieFile f = do
+  pm <- use_ GetParsedModule f
+  let normal_hie_f = toNormalizedFilePath hie_f
+      hie_f = ml_hie_file $ ms_location $ pm_mod_summary pm
+  mbHieTimestamp <- use GetModificationTime normal_hie_f
+  srcTimestamp   <- use_ GetModificationTime f
+  case (mbHieTimestamp, srcTimestamp) of
+    (Just hie, src)
+      | comparing modificationTime hie src == GT -> pure ()
+    _ -> do
+      -- typecheck generates a .hie file as a side effect
+      void $ use_ TypeCheck f
+  hf <- liftIO $ loadHieFile hie_f
+  return ([], Just hf)
+
+getPackageHieFile :: Module             -- ^ Package Module to load .hie file for
+                  -> NormalizedFilePath -- ^ Path of home module importing the package module
+                  -> Action (Maybe (HieFile, FilePath))
+getPackageHieFile mod file = do
+    pkgState  <- hscEnv <$> use_ GhcSession file
+    IdeOptions {..} <- getIdeOptions
+    let unitId = moduleUnitId mod
+    case lookupPackageConfig unitId pkgState of
+        Just pkgConfig -> do
+            hieFile <- liftIO $ optLocateHieFile optPkgLocationOpts pkgConfig mod
+            path    <- liftIO $ optLocateSrcFile optPkgLocationOpts pkgConfig mod
+            case (hieFile, path) of
+                (Just hiePath, Just modPath) -> liftIO $ do
+                    -- deliberately loaded outside the Shake graph
+                    -- to avoid dependencies on non-workspace files
+                    foundIt <- IO.doesFileExist hiePath
+                    if foundIt
+                        then Just . (, modPath) <$> loadHieFile hiePath
+                        else return Nothing
+                _ -> return Nothing
+        _ -> return Nothing
 
 -- | Parse the contents of a daml file.
 getParsedModule :: NormalizedFilePath -> Action (Maybe ParsedModule)
@@ -346,14 +396,6 @@ loadGhcSession = do
         opts <- getIdeOptions
         return ("" <$ optShakeFiles opts, ([], Just val))
 
-
-getHieFileRule :: Rules ()
-getHieFileRule =
-    defineNoFile $ \(GetHieFile f) -> do
-        u <- liftIO $ mkSplitUniqSupply 'a'
-        let nameCache = initNameCache u []
-        liftIO $ fmap (hie_file_result . fst) $ readHieFile nameCache f
-
 -- | A rule that wires per-file rules together
 mainRule :: Rules ()
 mainRule = do
@@ -367,4 +409,3 @@ mainRule = do
     generateCoreRule
     generateByteCodeRule
     loadGhcSession
-    getHieFileRule

--- a/src/Development/IDE/GHC/Compat.hs
+++ b/src/Development/IDE/GHC/Compat.hs
@@ -14,6 +14,9 @@ module Development.IDE.GHC.Compat(
     readHieFile,
     setDefaultHieDir,
     dontWriteHieFiles,
+#if !MIN_GHC_API_VERSION(8,8,0)
+    ml_hie_file,
+#endif
     hPutStringBuffer,
     includePathsGlobal,
     includePathsQuote,
@@ -52,12 +55,10 @@ import System.IO
 import Foreign.ForeignPtr
 
 
-#if !MIN_GHC_API_VERSION(8,8,0)
 hPutStringBuffer :: Handle -> StringBuffer -> IO ()
 hPutStringBuffer hdl (StringBuffer buf len cur)
     = withForeignPtr (plusForeignPtr buf cur) $ \ptr ->
              hPutBuf hdl ptr len
-#endif
 
 mkHieFile :: ModSummary -> TcGblEnv -> RenamedSource -> Hsc HieFile
 mkHieFile _ _ _ = return (HieFile () [])
@@ -67,6 +68,9 @@ writeHieFile _ _ = return ()
 
 readHieFile :: NameCache -> FilePath -> IO (HieFileResult, ())
 readHieFile _ _ = return (HieFileResult (HieFile () []), ())
+
+ml_hie_file :: GHC.ModLocation -> FilePath
+ml_hie_file _ = ""
 
 data HieFile = HieFile {hie_module :: (), hie_exports :: [AvailInfo]}
 data HieFileResult = HieFileResult { hie_file_result :: HieFile }


### PR DESCRIPTION
`.hie` files are used instead of typecheck artifacts for `getDefinition` functionality when using interface files, as they lack located typechecked ASTs.

We choose to never store .hie files in the Shake graph, as they are
- expensive in space
- quick to load
- only used for go to definition

While there, we remove package module .hie files from the Shake graph too.