### PR TITLE
Group Imports in Outline into a single node

### DIFF
--- a/src/Development/IDE/LSP/Outline.hs
+++ b/src/Development/IDE/LSP/Outline.hs
@@ -50,7 +50,9 @@ moduleOutline _lsp ideState DocumentSymbolParams { _textDocument = TextDocumentI
                    , _kind  = SkFile
                    , _range = Range (Position 0 0) (Position maxBound 0) -- _ltop is 0 0 0 0
                    }
-               importSymbols = documentSymbolForImportSummary (mapMaybe documentSymbolForImport hsmodImports)
+               importSymbols = maybe [] pure $
+                  documentSymbolForImportSummary
+                    (mapMaybe documentSymbolForImport hsmodImports)
                allSymbols    = case moduleSymbol of
                  Nothing -> importSymbols <> declSymbols
                  Just x ->
@@ -170,15 +172,15 @@ documentSymbolForDecl _ = Nothing
 -- | Wrap the Document imports into a hierarchical outline for
 -- a better overview of symbols in scope.
 -- If there are no imports, then no hierarchy will be created.
-documentSymbolForImportSummary :: [DocumentSymbol] -> [DocumentSymbol]
-documentSymbolForImportSummary [] = []
+documentSymbolForImportSummary :: [DocumentSymbol] -> Maybe DocumentSymbol
+documentSymbolForImportSummary [] = Nothing
 documentSymbolForImportSummary importSymbols =
     let
       -- safe because if we have no ranges then we don't take this branch
       mergeRanges xs = Range (minimum $ map _start xs) (maximum $ map _end xs)
       importRange = mergeRanges $ map (_range :: DocumentSymbol -> Range) importSymbols
     in
-      pure (defDocumentSymbol empty :: DocumentSymbol)
+      Just (defDocumentSymbol empty :: DocumentSymbol)
           { _name = "imports"
           , _kind = SkModule
           , _children = Just (List importSymbols)

--- a/src/Development/IDE/LSP/Outline.hs
+++ b/src/Development/IDE/LSP/Outline.hs
@@ -50,7 +50,7 @@ moduleOutline _lsp ideState DocumentSymbolParams { _textDocument = TextDocumentI
                    , _kind  = SkFile
                    , _range = Range (Position 0 0) (Position maxBound 0) -- _ltop is 0 0 0 0
                    }
-               importSymbols = mapMaybe documentSymbolForImport hsmodImports
+               importSymbols = documentSymbolForImportSummary (mapMaybe documentSymbolForImport hsmodImports)
                allSymbols    = case moduleSymbol of
                  Nothing -> importSymbols <> declSymbols
                  Just x ->
@@ -166,6 +166,25 @@ documentSymbolForDecl (L l (ForD x)) = Just
   where name = showRdrName $ unLoc $ fd_name x
 
 documentSymbolForDecl _ = Nothing
+
+-- | Wrap the Document imports into a hierarchical outline for
+-- a better overview of symbols in scope.
+-- If there are no imports, then no hierarchy will be created.
+documentSymbolForImportSummary :: [DocumentSymbol] -> [DocumentSymbol]
+documentSymbolForImportSummary [] = []
+documentSymbolForImportSummary importSymbols =
+    let
+      -- safe because if we have no ranges then we don't take this branch
+      mergeRanges xs = Range (minimum $ map _start xs) (maximum $ map _end xs)
+      importRange = mergeRanges $ map (_range :: DocumentSymbol -> Range) importSymbols
+    in
+      pure (defDocumentSymbol empty :: DocumentSymbol)
+          { _name = "imports"
+          , _kind = SkModule
+          , _children = Just (List importSymbols)
+          , _range = importRange
+          , _selectionRange = importRange
+          }
 
 documentSymbolForImport :: Located (ImportDecl GhcPs) -> Maybe DocumentSymbol
 documentSymbolForImport (L l ImportDecl { ideclName, ideclQualified }) = Just

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -1656,7 +1656,24 @@ outlineTests = testGroup
     docId   <- openDoc' "A.hs" "haskell" source
     symbols <- getDocumentSymbols docId
     liftIO $ symbols @?= Left
-      [docSymbol "import Data.Maybe" SkModule (R 0 0 0 17)]
+      [docSymbolWithChildren "imports" 
+                             SkModule 
+                             (R 0 0 0 17)
+                             [ docSymbol "import Data.Maybe" SkModule (R 0 0 0 17) 
+                             ]
+      ]
+  , testSessionWait "multiple import" $ do
+    let source = T.unlines ["", "import Data.Maybe", "", "import Control.Exception", ""]
+    docId   <- openDoc' "A.hs" "haskell" source
+    symbols <- getDocumentSymbols docId
+    liftIO $ symbols @?= Left
+      [docSymbolWithChildren "imports" 
+                             SkModule 
+                             (R 1 0 3 24)
+                             [ docSymbol "import Data.Maybe" SkModule (R 1 0 1 17)
+                             , docSymbol "import Control.Exception" SkModule (R 3 0 3 24) 
+                             ]
+      ]
   , testSessionWait "foreign import" $ do
     let source = T.unlines
           [ "{-# language ForeignFunctionInterface #-}"


### PR DESCRIPTION
Makes it easier to see symbols in scope when you have lots of
import statements.

Bikeshedding:
Should a single imports still be wrapped into a DocumentSymbol?

In manual tests, behaviour is as I would have expected it.
@ocharles Can you test if your work-flow still works?

closes #438