### PR TITLE
Cache NormalizedFilePath in ArtifactLocation

### DIFF
--- a/src/Development/IDE/Import/FindImports.hs
+++ b/src/Development/IDE/Import/FindImports.hs
@@ -34,11 +34,14 @@ data Import
   | PackageImport !M.InstalledUnitId
   deriving (Show)
 
-newtype ArtifactsLocation =  ArtifactsLocation ModLocation
+data ArtifactsLocation = ArtifactsLocation
+  { artifactFilePath :: !NormalizedFilePath
+  , artifactModLocation :: !ModLocation
+  }
     deriving (Show)
 
 instance NFData ArtifactsLocation where
-  rnf = const ()
+  rnf ArtifactsLocation{..} = rnf artifactFilePath `seq` rwhnf artifactModLocation
 
 instance NFData Import where
   rnf (FileImport x) = rnf x
@@ -94,7 +97,7 @@ locateModule dflags exts doesExist modName mbPkgName isSource = do
   where
     toModLocation file = liftIO $ do
         loc <- mkHomeModLocation dflags (unLoc modName) (fromNormalizedFilePath file)
-        return $ Right $ FileImport $ ArtifactsLocation loc
+        return $ Right $ FileImport $ ArtifactsLocation file loc
 
 
     lookupInPackageDB dfs =


### PR DESCRIPTION
Previously `PathIdMap` cached `NormalizedFilePath` values, but with the addition of module data those got dropped.

It's probably a good idea to bring them back to avoid the risk of a perf regression