### PR TITLE
Build against lts-15.0 and GHC 8.8.2

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,17 +1,6 @@
-resolver: nightly-2019-09-21
+resolver: lts-15.0
 packages:
 - .
-extra-deps:
-- haskell-lsp-0.20.0.0
-- haskell-lsp-types-0.20.0.0
-- lsp-test-0.10.1.0
-- hie-bios-0.4.0
-- fuzzy-0.1.0.0
-- regex-pcre-builtin-0.95.1.1.8.43
-- regex-base-0.94.0.0
-- regex-tdfa-1.3.1.0
-- shake-0.18.5
-- parser-combinators-1.2.1
-- haddock-library-1.8.0
+extra-deps: []
 nix:
   packages: [zlib]


### PR DESCRIPTION
Just for testing, I needed **ghcide** built with GHC 8.8.2, so I tried `lts-15.0`. Everything it needs to build is in the stable snapshot now, so the _stack.yaml_ simplified somewhat. Everything appears to be working.

Concurrently I decided to build **stack** from `'master'` in order to make the annoying warning about untested versions of compiler and Cabal go away, but that was cosmetic.