### PR TITLE
Fix regression in cradle loading logic

### DIFF
--- a/exe/RuleTypes.hs
+++ b/exe/RuleTypes.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE TypeFamilies #-}
+module RuleTypes (GetHscEnv(..), LoadCradle(..)) where
+
+import Control.DeepSeq
+import Data.Binary
+import Data.Hashable (Hashable)
+import Development.Shake
+import Development.IDE.GHC.Util
+import Data.Typeable (Typeable)
+import GHC.Generics (Generic)
+
+-- Rule type for caching GHC sessions.
+type instance RuleResult GetHscEnv = HscEnvEq
+
+data GetHscEnv = GetHscEnv
+    { hscenvOptions :: [String]        -- componentOptions from hie-bios
+    , hscenvDependencies :: [FilePath] -- componentDependencies from hie-bios
+    }
+    deriving (Eq, Show, Typeable, Generic)
+
+instance Hashable GetHscEnv
+instance NFData   GetHscEnv
+instance Binary   GetHscEnv
+
+-- Rule type for caching cradle loading
+type instance RuleResult LoadCradle = HscEnvEq
+
+data LoadCradle = LoadCradle
+    deriving (Eq, Show, Typeable, Generic)
+
+instance Hashable LoadCradle
+instance NFData   LoadCradle
+instance Binary   LoadCradle

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -194,6 +194,7 @@ executable ghcide
     other-modules:
         Arguments
         Paths_ghcide
+        RuleTypes
 
     default-extensions:
         DeriveGeneric


### PR DESCRIPTION
We were calling `runCradle` multiple times per cradle, concurrently. For Cabal
cradles this function runs Cabal, which is neither fast nor designed to be run
concurrently

Fixes #446 