### PR TITLE
Adjust PR #377 for GHC 8.10 (DynFlags/Settings optP)

### DIFF
--- a/src/Development/IDE/Core/Preprocessor.hs
+++ b/src/Development/IDE/Core/Preprocessor.hs
@@ -166,18 +166,11 @@ runLhs dflags filename contents = withTempDir $ \dir -> do
     escape (c:cs)    = c : escape cs
     escape []        = []
 
-
-modifyOptP :: ([String] -> [String]) -> DynFlags -> DynFlags
-modifyOptP op = onSettings (onOptP op)
-  where
-    onSettings f x = x{settings = f $ settings x}
-    onOptP f x = x{sOpt_P = f $ sOpt_P x}
-
 -- | Run CPP on a file
 runCpp :: DynFlags -> FilePath -> Maybe SB.StringBuffer -> IO SB.StringBuffer
 runCpp dflags filename contents = withTempDir $ \dir -> do
     let out = dir </> takeFileName filename <.> "out"
-    dflags <- pure $ modifyOptP ("-D__GHCIDE__":) dflags
+    dflags <- pure $ addOptP "-D__GHCIDE__" dflags
 
     case contents of
         Nothing -> do


### PR DESCRIPTION
Unfortunately PR #377, which was meant to help with GHC 8.10 compatibility, also requires a fix for GHC 8.10.

Recent versions of GHC's `DynFlags` module define an [`addOptP` function](https://gitlab.haskell.org/ghc/ghc/blob/ghc-8.10/compiler/main/DynFlags.hs#L2716), but it is unfortunately not exported, so the definition is copied here.

With this additional fix, the master branch of `ghcide` builds on GHC 8.10 rc1 on my end.