### PR TITLE
Refactoring: remove isTesting from ShakeExtras

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -95,7 +95,7 @@ main = do
             let options = (defaultIdeOptions $ loadSession dir)
                     { optReportProgress = clientSupportsProgress caps
                     , optShakeProfiling = argsShakeProfiling
-                    , optTesting        = IdeTesting argsTesting
+                    , optTesting        = argsTesting
                     }
             debouncer <- newAsyncDebouncer
             initialise caps (cradleRules >> mainRule >> pluginRules plugins >> action kick)

--- a/src/Development/IDE/Core/Service.hs
+++ b/src/Development/IDE/Core/Service.hs
@@ -61,7 +61,6 @@ initialise caps mainRule getLspId toDiags logger debouncer options vfs =
         logger
         debouncer
         (optShakeProfiling options)
-        (optTesting options)
         (optReportProgress options)
         shakeOptions
           { shakeThreads = optThreads options

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -102,8 +102,6 @@ data ShakeExtras = ShakeExtras
     -- positions in a version of that document to positions in the latest version
     ,inProgress :: Var (HMap.HashMap NormalizedFilePath Int)
     -- ^ How many rules are running for each file
-    ,isTesting :: Bool
-    -- ^ enable additional messages used by the test suite to check invariants
     }
 
 getShakeExtras :: Action ShakeExtras
@@ -299,12 +297,11 @@ shakeOpen :: IO LSP.LspId
           -> Logger
           -> Debouncer NormalizedUri
           -> Maybe FilePath
-          -> IdeTesting
           -> IdeReportProgress
           -> ShakeOptions
           -> Rules ()
           -> IO IdeState
-shakeOpen getLspId eventer logger debouncer shakeProfileDir (IdeTesting isTesting) (IdeReportProgress reportProgress) opts rules = do
+shakeOpen getLspId eventer logger debouncer shakeProfileDir (IdeReportProgress reportProgress) opts rules = do
     inProgress <- newVar HMap.empty
     shakeExtras <- do
         globals <- newVar HMap.empty

--- a/src/Development/IDE/Types/Options.hs
+++ b/src/Development/IDE/Types/Options.hs
@@ -9,7 +9,6 @@ module Development.IDE.Types.Options
   , IdePreprocessedSource(..)
   , IdeReportProgress(..)
   , IdeDefer(..)
-  , IdeTesting(..)
   , clientSupportsProgress
   , IdePkgLocationOptions(..)
   , defaultIdeOptions
@@ -41,7 +40,7 @@ data IdeOptions = IdeOptions
   -- meaning we keep everything in memory but the daml CLI compiler uses this for incremental builds.
   , optShakeProfiling :: Maybe FilePath
     -- ^ Set to 'Just' to create a directory of profiling reports.
-  , optTesting :: IdeTesting
+  , optTesting :: Bool
     -- ^ Whether to enable additional lsp messages used by the test suite for checking invariants
   , optReportProgress :: IdeReportProgress
     -- ^ Whether to report progress during long operations.
@@ -68,7 +67,6 @@ data IdePreprocessedSource = IdePreprocessedSource
 
 newtype IdeReportProgress = IdeReportProgress Bool
 newtype IdeDefer          = IdeDefer          Bool
-newtype IdeTesting        = IdeTesting        Bool
 
 clientSupportsProgress :: LSP.ClientCapabilities -> IdeReportProgress
 clientSupportsProgress caps = IdeReportProgress $ Just True ==
@@ -87,7 +85,7 @@ defaultIdeOptions session = IdeOptions
     ,optLanguageSyntax = "haskell"
     ,optNewColonConvention = False
     ,optDefer = IdeDefer True
-    ,optTesting = IdeTesting False
+    ,optTesting = False
     }
 
 


### PR DESCRIPTION
isTesting got added to ShakeExtras unnecessarily