### PR TITLE
Use tasty-rerun to allow rerunning failed tests only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist-newstyle/
 cabal.project.local
 *~
 *.lock
+/.tasty-rerun-log

--- a/README.md
+++ b/README.md
@@ -254,6 +254,13 @@ To build and work on `ghcide` itself, you can use Stack or cabal, e.g.,
 running `stack test` will execute the test suite.
 If you are using Windows, you should disable the `auto.crlf` setting and configure your editor to use LF line endings, directly or making it use the existing `.editor-config`.
 
+If you are chasing down test failures, you can use the tasty-rerun feature by running tests as
+
+    stack --stack-yaml=stack84.yaml test --test-arguments "--rerun"
+
+This writes a log file called `.tasty-rerun-log` of the failures, and only runs those.
+See the [tasty-rerun](https://hackage.haskell.org/package/tasty-rerun-1.1.17/docs/Test-Tasty-Ingredients-Rerun.html) documentation for other options.
+
 ### Building the extension
 
 For development, you can also the VSCode extension from this repository (see

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -255,6 +255,7 @@ test-suite ghcide-tests
         tasty-expected-failure,
         tasty-hunit,
         tasty-quickcheck,
+        tasty-rerun,
         text
     hs-source-dirs: test/cabal test/exe test/src
     include-dirs: include

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,5 +13,6 @@ extra-deps:
 - shake-0.18.5
 - parser-combinators-1.2.1
 - haddock-library-1.8.0
+- tasty-rerun-1.1.17
 nix:
   packages: [zlib]

--- a/stack84.yaml
+++ b/stack84.yaml
@@ -22,5 +22,11 @@ extra-deps:
 - unordered-containers-0.2.10.0
 - file-embed-0.0.11.2
 - heaps-0.3.6.1
+
+# For tasty-retun
+- ansi-terminal-0.10.3
+- ansi-wl-pprint-0.6.9
+- tasty-1.2.3
+- tasty-rerun-1.1.17
 nix:
   packages: [zlib]

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -39,12 +39,13 @@ import Test.QuickCheck
 import Test.QuickCheck.Instances ()
 import Test.Tasty
 import Test.Tasty.ExpectedFailure
+import Test.Tasty.Ingredients.Rerun
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
 import Data.Maybe
 
 main :: IO ()
-main = defaultMain $ testGroup "HIE"
+main = defaultMainWithRerun $ testGroup "HIE"
   [ testSession "open close" $ do
       doc <- openDoc' "Testing.hs" "haskell" ""
       void (skipManyTill anyMessage message :: Session WorkDoneProgressCreateRequest)


### PR DESCRIPTION
Use by

  stack --stack-yaml=stack84.yaml test --test-arguments "--rerun"