### PR TITLE
Expose underlying hover and gotoDefinition handlers

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -111,6 +111,7 @@ library
         Development.IDE.GHC.Error
         Development.IDE.GHC.Util
         Development.IDE.Import.DependencyInformation
+        Development.IDE.LSP.HoverDefinition
         Development.IDE.LSP.LanguageServer
         Development.IDE.LSP.Protocol
         Development.IDE.LSP.Server
@@ -131,7 +132,6 @@ library
         Development.IDE.GHC.Orphans
         Development.IDE.GHC.Warnings
         Development.IDE.Import.FindImports
-        Development.IDE.LSP.HoverDefinition
         Development.IDE.LSP.Notifications
         Development.IDE.LSP.Outline
         Development.IDE.Spans.AtPoint

--- a/src/Development/IDE/LSP/HoverDefinition.hs
+++ b/src/Development/IDE/LSP/HoverDefinition.hs
@@ -6,6 +6,9 @@
 module Development.IDE.LSP.HoverDefinition
     ( setHandlersHover
     , setHandlersDefinition
+    -- * For haskell-language-server
+    , hover
+    , gotoDefinition
     ) where
 
 import           Development.IDE.Core.Rules


### PR DESCRIPTION
For use in haskell-language-server

The way `PartialHandler`s are chained in ghcide means earlier ones get masked by ones added later in the chain.

haskell-language-server puts a hover handler in to the custom area, which combines the output of all configured hover handlers.

This change allows hls to include the underlying one for ghcide.

We treat gotoDefinition the same way, if we choose to combine them at the plugin level.