### PR TITLE
Make keywords customizable

### DIFF
--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -373,7 +373,9 @@ getCompletions ideOpts CC { allModNamesAsNS, unqualCompls, qualCompls, importabl
       filtImportCompls = filtListWith (mkImportCompl enteredQual) importableModules
       filtPragmaCompls = filtListWithSnippet mkPragmaCompl validPragmas
       filtOptsCompls   = filtListWith mkExtCompl
-      filtKeywordCompls = if T.null prefixModule then filtListWith mkExtCompl keywords else []
+      filtKeywordCompls
+          | T.null prefixModule = filtListWith mkExtCompl (optKeywords ideOpts)
+          | otherwise = []
 
       stripLeading :: Char -> String -> String
       stripLeading _ [] = []
@@ -526,25 +528,4 @@ prefixes =
   , "$t"
   , "$c"
   , "$m"
-  ]
-
-keywords :: [T.Text]
-keywords =
-  [
-    -- From https://wiki.haskell.org/Keywords
-    "as"
-  , "case", "of"
-  , "class", "instance", "type"
-  , "data", "family", "newtype"
-  , "default"
-  , "deriving"
-  , "do", "mdo", "proc", "rec"
-  , "forall"
-  , "foreign"
-  , "hiding"
-  , "if", "then", "else"
-  , "import", "qualified", "hiding"
-  , "infix", "infixl", "infixr"
-  , "let", "in", "where"
-  , "module"
   ]

--- a/src/Development/IDE/Types/Options.hs
+++ b/src/Development/IDE/Types/Options.hs
@@ -19,6 +19,7 @@ import Development.IDE.GHC.Util
 import           GHC hiding (parseModule, typecheckModule)
 import           GhcPlugins                     as GHC hiding (fst3, (<>))
 import qualified Language.Haskell.LSP.Types.Capabilities as LSP
+import qualified Data.Text as T
 
 data IdeOptions = IdeOptions
   { optPreprocessor :: GHC.ParsedSource -> IdePreprocessedSource
@@ -48,6 +49,9 @@ data IdeOptions = IdeOptions
     -- ^ the ```language to use
   , optNewColonConvention :: Bool
     -- ^ whether to use new colon convention
+  , optKeywords :: [T.Text]
+    -- ^ keywords used for completions. These are customizable
+    -- since DAML has a different set of keywords than Haskell.
   , optDefer :: IdeDefer
     -- ^ Whether to defer type errors, typed holes and out of scope
     --   variables. Deferral allows the IDE to continue to provide
@@ -84,6 +88,7 @@ defaultIdeOptions session = IdeOptions
     ,optReportProgress = IdeReportProgress False
     ,optLanguageSyntax = "haskell"
     ,optNewColonConvention = False
+    ,optKeywords = haskellKeywords
     ,optDefer = IdeDefer True
     ,optTesting = False
     }
@@ -103,3 +108,23 @@ data IdePkgLocationOptions = IdePkgLocationOptions
 defaultIdePkgLocationOptions :: IdePkgLocationOptions
 defaultIdePkgLocationOptions = IdePkgLocationOptions f f
     where f _ _ = return Nothing
+
+-- | From https://wiki.haskell.org/Keywords
+haskellKeywords :: [T.Text]
+haskellKeywords =
+  [ "as"
+  , "case", "of"
+  , "class", "instance", "type"
+  , "data", "family", "newtype"
+  , "default"
+  , "deriving"
+  , "do", "mdo", "proc", "rec"
+  , "forall"
+  , "foreign"
+  , "hiding"
+  , "if", "then", "else"
+  , "import", "qualified", "hiding"
+  , "infix", "infixl", "infixr"
+  , "let", "in", "where"
+  , "module"
+  ]


### PR DESCRIPTION
This is necessary for DAML where we have additional
keywords (e.g. `with`) and other keywords don’t
exist (e.g. `foreign`).

I considered using just a modify function `[T.Text] -> [T.Text]`
but decided against it in the end. The list is small enough and I
think it’s much easier to understand with an explicit enumeration (and
you can just show the field in the options which is often convenient
for debugging).