### PR TITLE
Improve completion contexts

### DIFF
--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -210,9 +210,10 @@ mkPragmaCompl label insertText =
     Nothing Nothing Nothing Nothing Nothing (Just insertText) (Just Snippet)
     Nothing Nothing Nothing Nothing Nothing
 
-cacheDataProducer :: HscEnv -> DynFlags -> TypecheckedModule -> [ParsedModule] -> IO CachedCompletions
-cacheDataProducer packageState dflags tm deps = do
+cacheDataProducer :: HscEnv -> TypecheckedModule -> [ParsedModule] -> IO CachedCompletions
+cacheDataProducer packageState tm deps = do
   let parsedMod = tm_parsed_module tm
+      dflags = hsc_dflags packageState
       curMod = moduleName $ ms_mod $ pm_mod_summary parsedMod
       Just (_,limports,_,_) = tm_renamed_source tm
 
@@ -306,15 +307,12 @@ toggleSnippets ClientCapabilities { _textDocument } (WithSnippets with) x
   where supported = Just True == (_textDocument >>= _completion >>= _completionItem >>= _snippetSupport)
 
 -- | Returns the cached completions for the given module and position.
-getCompletions :: IdeOptions -> CachedCompletions -> TypecheckedModule -> VFS.PosPrefixInfo -> ClientCapabilities -> WithSnippets -> IO [CompletionItem]
+getCompletions :: IdeOptions -> CachedCompletions -> ParsedModule -> VFS.PosPrefixInfo -> ClientCapabilities -> WithSnippets -> IO [CompletionItem]
 getCompletions ideOpts CC { allModNamesAsNS, unqualCompls, qualCompls, importableModules }
-               tm prefixInfo caps withSnippets = do
+               pm prefixInfo caps withSnippets = do
   let VFS.PosPrefixInfo { VFS.fullLine, VFS.prefixModule, VFS.prefixText } = prefixInfo
       enteredQual = if T.null prefixModule then "" else prefixModule <> "."
       fullPrefix  = enteredQual <> prefixText
-
-      -- default to value context if no explicit context
-      context = fromMaybe ValueContext $ getCContext pos (tm_parsed_module tm)
 
       {- correct the position by moving 'foo :: Int -> String ->    '
                                                                     ^
@@ -344,10 +342,11 @@ getCompletions ideOpts CC { allModNamesAsNS, unqualCompls, qualCompls, importabl
         where
           isTypeCompl = isTcOcc . occName . origName
           -- completions specific to the current context
-          ctxCompls' = case context of
-                        TypeContext -> filter isTypeCompl compls
-                        ValueContext -> filter (not . isTypeCompl) compls
-                        _ -> filter (not . isTypeCompl) compls
+          ctxCompls' = case getCContext pos pm of
+                        Nothing -> compls
+                        Just TypeContext -> filter isTypeCompl compls
+                        Just ValueContext -> filter (not . isTypeCompl) compls
+                        Just _ -> filter (not . isTypeCompl) compls
           -- Add whether the text to insert has backticks
           ctxCompls = map (\comp -> comp { isInfix = infixCompls }) ctxCompls'
 


### PR DESCRIPTION
The completion context determines whether we show completions for
types or completions for values. This is done by looking at the parsed
module.

This PR fixes two things:

1. While we only use the parsed module for getting the context
   previously we got the parsed module out of the typechecked
   module. This means that if you have a module that parses but
   doesn’t typecheck, we will use the parsed module at the point where
   it last typechecked which is out of date and produces incorrect (or
   just no) contexts.
2. When we could not find a context, we defaulted to assuming we are
   in a value context. Especially in combination with 1 but also just
   in general, this is rather annoying. If we aren’t sure we should
   show the user everything we have and not filter out some
   completions. Filtering out completions interacts particularly badly
   with VSCode’s default behavior of accepting the first completion
   when you press return.