### PR TITLE
Allow disabling the simplifier in compileModule

### DIFF
--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -351,17 +351,17 @@ typeCheckRule =
         addByteCode :: Linkable -> TcModuleResult -> TcModuleResult
         addByteCode lm tmr = tmr { tmrModInfo = (tmrModInfo tmr) { hm_linkable = Just lm } }
 
-generateCore :: NormalizedFilePath -> Action (IdeResult (SafeHaskellMode, CgGuts, ModDetails))
-generateCore file = do
+generateCore :: RunSimplifier -> NormalizedFilePath -> Action (IdeResult (SafeHaskellMode, CgGuts, ModDetails))
+generateCore runSimplifier file = do
     deps <- use_ GetDependencies file
     (tm:tms) <- uses_ TypeCheck (file:transitiveModuleDeps deps)
     setPriority priorityGenerateCore
     packageState <- hscEnv <$> use_ GhcSession file
-    liftIO $ compileModule packageState tms tm
+    liftIO $ compileModule runSimplifier packageState tms tm
 
 generateCoreRule :: Rules ()
 generateCoreRule =
-    define $ \GenerateCore -> generateCore
+    define $ \GenerateCore -> generateCore (RunSimplifier True)
 
 generateByteCodeRule :: Rules ()
 generateByteCodeRule =


### PR DESCRIPTION
It causes problems for our conversion to DAML-LF atm and isn’t
necessary (since we don’t have template Haskell) so let’s make it
configurable. I originally thought we could just copy paste all of
compileModule to DAML but it turns out that this pull in too much
stuff that I don’t want to see diverge from `ghcide` so I abandoned
that idea.