### PR TITLE
Add a custom prefix to command IDs

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -76,6 +76,7 @@
   - {name: ImplicitParams, within: []}
   - name: CPP
     within:
+    - Development.IDE.Compat
     - Development.IDE.Core.FileStore
     - Development.IDE.Core.Compile
     - Development.IDE.GHC.Compat

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -86,7 +86,7 @@ main = do
     let plugins = Completions.plugin <> CodeAction.plugin
         onInitialConfiguration = const $ Right ()
         onConfigurationChange  = const $ Right ()
-        options = def { LSP.executeCommandCommands = Just [pid <> ":typesignature.add"]
+        options = def { LSP.executeCommandCommands = Just [pid <> ":ghcide:typesignature.add"]
                       , LSP.completionTriggerCharacters = Just "."
                       }
 

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -81,11 +81,12 @@ main = do
     whenJust argsCwd IO.setCurrentDirectory
 
     dir <- IO.getCurrentDirectory
+    pid <- getPid
 
     let plugins = Completions.plugin <> CodeAction.plugin
         onInitialConfiguration = const $ Right ()
         onConfigurationChange  = const $ Right ()
-        options = def { LSP.executeCommandCommands = Just ["typesignature.add"]
+        options = def { LSP.executeCommandCommands = Just [pid <> ":typesignature.add"]
                       , LSP.completionTriggerCharacters = Just "."
                       }
 

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -81,12 +81,12 @@ main = do
     whenJust argsCwd IO.setCurrentDirectory
 
     dir <- IO.getCurrentDirectory
-    pid <- getPid
+    command <- makeLspCommandId "typesignature.add"
 
     let plugins = Completions.plugin <> CodeAction.plugin
         onInitialConfiguration = const $ Right ()
         onConfigurationChange  = const $ Right ()
-        options = def { LSP.executeCommandCommands = Just [pid <> ":ghcide:typesignature.add"]
+        options = def { LSP.executeCommandCommands = Just [command]
                       , LSP.completionTriggerCharacters = Just "."
                       }
 

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -73,7 +73,10 @@ library
         ghc-boot-th,
         ghc-boot,
         ghc >= 8.4
-    if !os(windows)
+    if os(windows)
+      build-depends:
+        Win32
+    else
       build-depends:
         unix
       c-sources:

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -99,6 +99,7 @@ library
     include-dirs:
         include
     exposed-modules:
+        Development.IDE.Compat
         Development.IDE.Core.Debouncer
         Development.IDE.Core.FileStore
         Development.IDE.Core.IdeConfiguration

--- a/src/Development/IDE/Compat.hs
+++ b/src/Development/IDE/Compat.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE CPP #-}
+module Development.IDE.Compat
+    (
+        getProcessID
+    ) where
+
+#ifdef mingw32_HOST_OS
+
+import qualified System.Win32.Process as P (getCurrentProcessId)
+getProcessID :: IO Int
+getProcessID = fromIntegral <$> P.getCurrentProcessId
+
+#else
+
+import qualified System.Posix.Process as P (getProcessID)
+getProcessID :: IO Int
+getProcessID = fromIntegral <$> P.getProcessID
+
+#endif

--- a/src/Development/IDE/Plugin.hs
+++ b/src/Development/IDE/Plugin.hs
@@ -1,5 +1,5 @@
 
-module Development.IDE.Plugin(Plugin(..), codeActionPlugin, codeActionPluginWithRules,getPid) where
+module Development.IDE.Plugin(Plugin(..), codeActionPlugin, codeActionPluginWithRules,makeLspCommandId,getPid) where
 
 import Data.Default
 import qualified Data.Text as T
@@ -38,5 +38,23 @@ codeActionPluginWithRules rr f = Plugin rr $ PartialHandlers $ \WithMessage{..} 
     where
       g lsp state (CodeActionParams a b c _) = fmap List <$> f lsp state a b c
 
+-- | Prefix to uniquely identify commands sent to the client.  This
+-- has two parts
+--
+-- - A representation of the process id to make sure that a client has
+--   unique commands if it is running multiple servers, since some
+--   clients have a global command table and get confused otherwise.
+--
+-- - A string to identify ghcide, to ease integration into
+--   haskell-language-server, which routes commands to plugins based
+--   on that.
+makeLspCommandId :: T.Text -> IO T.Text
+makeLspCommandId command = do
+    pid <- getPid
+    return $ pid <> ":ghcide:" <> command
+
+-- | Get the operating system process id for the running server
+-- instance. This should be the same for the lifetime of the instance,
+-- and different from that of any other currently running instance.
 getPid :: IO T.Text
 getPid = T.pack . show <$> getProcessID

--- a/src/Development/IDE/Plugin.hs
+++ b/src/Development/IDE/Plugin.hs
@@ -1,11 +1,13 @@
 
-module Development.IDE.Plugin(Plugin(..), codeActionPlugin, codeActionPluginWithRules) where
+module Development.IDE.Plugin(Plugin(..), codeActionPlugin, codeActionPluginWithRules,getPid) where
 
 import Data.Default
+import qualified Data.Text as T
 import Development.Shake
 import Development.IDE.LSP.Server
 
 import           Language.Haskell.LSP.Types
+import Development.IDE.Compat
 import Development.IDE.Core.Rules
 import qualified Language.Haskell.LSP.Core as LSP
 import Language.Haskell.LSP.Messages
@@ -35,3 +37,6 @@ codeActionPluginWithRules rr f = Plugin rr $ PartialHandlers $ \WithMessage{..} 
     }
     where
       g lsp state (CodeActionParams a b c _) = fmap List <$> f lsp state a b c
+
+getPid :: IO T.Text
+getPid = T.pack . show <$> getProcessID

--- a/src/Development/IDE/Plugin/CodeAction.hs
+++ b/src/Development/IDE/Plugin/CodeAction.hs
@@ -105,7 +105,11 @@ executeAddSignatureCommand
     -> ExecuteCommandParams
     -> IO (Either ResponseError Value, Maybe (ServerMethod, ApplyWorkspaceEditParams))
 executeAddSignatureCommand _lsp _ideState ExecuteCommandParams{..}
-    | _command == "typesignature.add"
+    -- _command is prefixed with a process ID, because certain clients
+    -- have a global command registry, and all commands must be
+    -- unique. And there can be more than one ghcide instance running
+    -- at a time against the same client.
+    | T.isSuffixOf "typesignature.add" _command
     , Just (List [edit]) <- _arguments
     , Success wedit <- fromJSON edit
     = return (Right Null, Just (WorkspaceApplyEdit, ApplyWorkspaceEditParams wedit))

--- a/src/Development/IDE/Plugin/CodeAction.hs
+++ b/src/Development/IDE/Plugin/CodeAction.hs
@@ -84,13 +84,14 @@ codeLens
     -> CodeLensParams
     -> IO (Either ResponseError (List CodeLens))
 codeLens _lsp ideState CodeLensParams{_textDocument=TextDocumentIdentifier uri} = do
+    pid <- getPid
     fmap (Right . List) $ case uriToFilePath' uri of
       Just (toNormalizedFilePath -> filePath) -> do
         _ <- runAction ideState $ runMaybeT $ useE TypeCheck filePath
         diag <- getDiagnostics ideState
         hDiag <- getHiddenDiagnostics ideState
         pure
-          [ CodeLens _range (Just (Command title "typesignature.add" (Just $ List [toJSON edit]))) Nothing
+          [ CodeLens _range (Just (Command title (pid <> ":ghcide:typesignature.add") (Just $ List [toJSON edit]))) Nothing
           | (dFile, _, dDiag@Diagnostic{_range=_range}) <- diag ++ hDiag
           , dFile == filePath
           , (title, tedit) <- suggestSignature False dDiag

--- a/src/Development/IDE/Plugin/CodeAction.hs
+++ b/src/Development/IDE/Plugin/CodeAction.hs
@@ -84,14 +84,14 @@ codeLens
     -> CodeLensParams
     -> IO (Either ResponseError (List CodeLens))
 codeLens _lsp ideState CodeLensParams{_textDocument=TextDocumentIdentifier uri} = do
-    pid <- getPid
+    commandId <- makeLspCommandId "typesignature.add"
     fmap (Right . List) $ case uriToFilePath' uri of
       Just (toNormalizedFilePath -> filePath) -> do
         _ <- runAction ideState $ runMaybeT $ useE TypeCheck filePath
         diag <- getDiagnostics ideState
         hDiag <- getHiddenDiagnostics ideState
         pure
-          [ CodeLens _range (Just (Command title (pid <> ":ghcide:typesignature.add") (Just $ List [toJSON edit]))) Nothing
+          [ CodeLens _range (Just (Command title commandId (Just $ List [toJSON edit]))) Nothing
           | (dFile, _, dDiag@Diagnostic{_range=_range}) <- diag ++ hDiag
           , dFile == filePath
           , (title, tedit) <- suggestSignature False dDiag

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -104,7 +104,7 @@ initializeResponseTests = withResource acquire release tests where
     , chk "NO doc link"               _documentLinkProvider  Nothing
     , chk "NO color"                         _colorProvider (Just $ ColorOptionsStatic False)
     , chk "NO folding range"          _foldingRangeProvider (Just $ FoldingRangeOptionsStatic False)
-    , chk "   execute command"      _executeCommandProvider (Just $ ExecuteCommandOptions $ List ["typesignature.add"])
+    , che "   execute command"      _executeCommandProvider (Just $ ExecuteCommandOptions $ List ["typesignature.add"])
     , chk "   workspace"                         _workspace (Just $ WorkspaceOptions (Just WorkspaceFolderOptions{_supported = Just True, _changeNotifications = Just ( WorkspaceFolderChangeNotificationsBool True )}))
     , chk "NO experimental"                   _experimental  Nothing
     ] where
@@ -119,6 +119,15 @@ initializeResponseTests = withResource acquire release tests where
       chk :: (Eq a, Show a) => TestName -> (InitializeResponseCapabilitiesInner -> a) -> a -> TestTree
       chk title getActual expected =
         testCase title $ getInitializeResponse >>= \ir -> expected @=? (getActual . innerCaps) ir
+
+      che :: TestName -> (InitializeResponseCapabilitiesInner -> Maybe ExecuteCommandOptions) -> Maybe ExecuteCommandOptions -> TestTree
+      che title getActual _expected = testCase title doTest
+        where
+            doTest = do
+                ir <- getInitializeResponse
+                let Just (ExecuteCommandOptions {_commands = List [command]}) = getActual $ innerCaps ir
+                True @=? (T.isSuffixOf "typesignature.add" command)
+
 
   innerCaps :: InitializeResponse -> InitializeResponseCapabilitiesInner
   innerCaps (ResponseMessage _ _ (Just (InitializeResponseCapabilities c)) _) = c


### PR DESCRIPTION
A client can run more than one instance of ghcide.  Some clients have a global
command registry, and all commands must be unique in that registry.

So to make the command ids unique, prefix them with the ghcide server process
id, as is done in haskell-ide-engine.