### PR TITLE
Parse module headers

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -85,6 +85,7 @@
     - Development.IDE.Spans.Documentation
     - Development.IDE.Spans.Common
     - Development.IDE.Plugin.CodeAction
+    - Development.IDE.Plugin.Completions
     - Development.IDE.Plugin.Completions.Logic
     - Main
 

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -133,6 +133,7 @@ library
         Development.IDE.GHC.CPP
         Development.IDE.GHC.Orphans
         Development.IDE.GHC.Warnings
+        Development.IDE.GHC.WithDynFlags
         Development.IDE.Import.FindImports
         Development.IDE.LSP.Notifications
         Development.IDE.Spans.AtPoint

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -451,9 +451,9 @@ getModSummaryFromBuffer fp dflags parsed = do
 
 -- | Given a buffer, env and filepath, produce a module summary by parsing only the imports.
 --   Runs preprocessors as needed.
-getModSummaryFromImports :: FilePath -> SB.StringBuffer -> HscEnv -> ExceptT [FileDiagnostic] IO ModSummary
+getModSummaryFromImports :: FilePath -> Maybe SB.StringBuffer -> HscEnv -> ExceptT [FileDiagnostic] IO ModSummary
 getModSummaryFromImports fp contents hsc_env = do
-    (contents, dflags) <- ExceptT $ evalGhcEnv hsc_env $ runExceptT $ preprocessor fp (Just contents)
+    (contents, dflags) <- ExceptT $ evalGhcEnv hsc_env $ runExceptT $ preprocessor fp contents
     (srcImports, textualImports, L _ moduleName) <-
         ExceptT $ first (diagFromErrMsgs "parser" dflags) <$> GHC.getHeaderImports dflags contents fp fp
     liftIO $ evaluate $ rnf srcImports

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -453,7 +453,7 @@ getModSummaryFromImports :: FilePath -> SB.StringBuffer -> HscEnv -> ExceptT [Fi
 getModSummaryFromImports fp contents hsc_env = do
     (contents, dflags) <- ExceptT $ evalGhcEnv hsc_env $ runExceptT $ preprocessor fp (Just contents)
     (srcImports, textualImports, L _ moduleName) <-
-        ExceptT $ first (diagFromErrMsgs "parser" dflags) <$> Hdr.getImports dflags contents fp fp
+        ExceptT $ first (diagFromErrMsgs "parser" dflags) <$> GHC.getHeaderImports dflags contents fp fp
     modLoc <- liftIO $ mkHomeModLocation dflags moduleName fp
     required_by_imports <- liftIO $ implicitRequirements hsc_env textualImports
 
@@ -463,7 +463,9 @@ getModSummaryFromImports fp contents hsc_env = do
         summary =
             ModSummary
                 { ms_mod          = mod
+#if MIN_GHC_API_VERSION(8,8,0)
                 , ms_hie_date     = Nothing
+#endif
                 , ms_hs_date      = error "Rules should not depend on ms_hs_date"
         -- When we are working with a virtual file we do not have a file date.
         -- To avoid silent issues where something is not processed because the date

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -82,6 +82,8 @@ import           System.FilePath
 import           System.Directory
 import           System.IO.Extra
 import Data.Either.Extra (maybeToEither)
+import Control.DeepSeq (rnf)
+import Control.Exception (evaluate)
 
 
 -- | Given a string buffer, return the string (after preprocessing) and the 'ParsedModule'.
@@ -454,6 +456,8 @@ getModSummaryFromImports fp contents hsc_env = do
     (contents, dflags) <- ExceptT $ evalGhcEnv hsc_env $ runExceptT $ preprocessor fp (Just contents)
     (srcImports, textualImports, L _ moduleName) <-
         ExceptT $ first (diagFromErrMsgs "parser" dflags) <$> GHC.getHeaderImports dflags contents fp fp
+    liftIO $ evaluate $ rnf srcImports
+    liftIO $ evaluate $ rnf textualImports
     modLoc <- liftIO $ mkHomeModLocation dflags moduleName fp
     required_by_imports <- liftIO $ implicitRequirements hsc_env textualImports
 

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -460,8 +460,11 @@ getModSummaryFromImports fp contents = do
     (contents, dflags) <- preprocessor fp contents
     (srcImports, textualImports, L _ moduleName) <-
         ExceptT $ liftIO $ first (diagFromErrMsgs "parser" dflags) <$> GHC.getHeaderImports dflags contents fp fp
+
+    -- Force bits that might keep the string buffer and DynFlags alive unnecessarily
     liftIO $ evaluate $ rnf srcImports
     liftIO $ evaluate $ rnf textualImports
+
     modLoc <- liftIO $ mkHomeModLocation dflags moduleName fp
 
     let mod = mkModule (thisPackage dflags) moduleName

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -478,7 +478,7 @@ getModSummaryFromImports fp contents = do
                 , ms_hs_date      = error "Rules should not depend on ms_hs_date"
         -- When we are working with a virtual file we do not have a file date.
         -- To avoid silent issues where something is not processed because the date
-        -- has not changed, we make sure that things blow up if they depend on the
+        -- has not changed, we make sure that things blow up if they depend on the date.
                 , ms_hsc_src      = sourceType
                 , ms_hspp_buf     = Nothing
                 , ms_hspp_file    = fp

--- a/src/Development/IDE/Core/Preprocessor.hs
+++ b/src/Development/IDE/Core/Preprocessor.hs
@@ -31,11 +31,13 @@ import qualified Data.Text as T
 import Outputable (showSDoc)
 import Control.DeepSeq (NFData(rnf))
 import Control.Exception (evaluate)
+import Control.Monad.IO.Class (MonadIO)
+import Exception (ExceptionMonad)
 
 
 -- | Given a file and some contents, apply any necessary preprocessors,
 --   e.g. unlit/cpp. Return the resulting buffer and the DynFlags it implies.
-preprocessor :: GhcMonad m => FilePath -> Maybe StringBuffer -> ExceptT [FileDiagnostic] m (StringBuffer, DynFlags)
+preprocessor :: (ExceptionMonad m, HasDynFlags m, MonadIO m) => FilePath -> Maybe StringBuffer -> ExceptT [FileDiagnostic] m (StringBuffer, DynFlags)
 preprocessor filename mbContents = do
     -- Perform unlit
     (isOnDisk, contents) <-
@@ -131,12 +133,12 @@ isLiterate x = takeExtension x `elem` [".lhs",".lhs-boot"]
 
 -- | This reads the pragma information directly from the provided buffer.
 parsePragmasIntoDynFlags
-    :: GhcMonad m
+    :: (ExceptionMonad m, HasDynFlags m, MonadIO m)
     => FilePath
     -> SB.StringBuffer
     -> m (Either [FileDiagnostic] DynFlags)
 parsePragmasIntoDynFlags fp contents = catchSrcErrors "pragmas" $ do
-    dflags0  <- getSessionDynFlags
+    dflags0  <- getDynFlags
     let opts = Hdr.getOptions dflags0 contents fp
     liftIO $ evaluate $ rnf opts
     (dflags, _, _) <- parseDynamicFilePragma dflags0 opts

--- a/src/Development/IDE/Core/Preprocessor.hs
+++ b/src/Development/IDE/Core/Preprocessor.hs
@@ -140,7 +140,10 @@ parsePragmasIntoDynFlags
 parsePragmasIntoDynFlags fp contents = catchSrcErrors "pragmas" $ do
     dflags0  <- getDynFlags
     let opts = Hdr.getOptions dflags0 contents fp
+
+    -- Force bits that might keep the dflags and stringBuffer alive unnecessarily
     liftIO $ evaluate $ rnf opts
+
     (dflags, _, _) <- parseDynamicFilePragma dflags0 opts
     return dflags
 

--- a/src/Development/IDE/Core/Preprocessor.hs
+++ b/src/Development/IDE/Core/Preprocessor.hs
@@ -29,6 +29,8 @@ import Data.IORef (IORef, modifyIORef, newIORef, readIORef)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Outputable (showSDoc)
+import Control.DeepSeq (NFData(rnf))
+import Control.Exception (evaluate)
 
 
 -- | Given a file and some contents, apply any necessary preprocessors,
@@ -136,6 +138,7 @@ parsePragmasIntoDynFlags
 parsePragmasIntoDynFlags fp contents = catchSrcErrors "pragmas" $ do
     dflags0  <- getSessionDynFlags
     let opts = Hdr.getOptions dflags0 contents fp
+    liftIO $ evaluate $ rnf opts
     (dflags, _, _) <- parseDynamicFilePragma dflags0 opts
     return dflags
 

--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -105,6 +105,10 @@ type instance RuleResult GetModIface = HiFileResult
 
 type instance RuleResult IsFileOfInterest = Bool
 
+-- | Generate a ModSummary that has enough information to be used to get .hi and .hie files.
+-- without needing to parse the entire source
+type instance RuleResult GetModSummary = ModSummary
+
 data GetParsedModule = GetParsedModule
     deriving (Eq, Show, Typeable, Generic)
 instance Hashable GetParsedModule
@@ -177,9 +181,14 @@ instance Hashable GetModIface
 instance NFData   GetModIface
 instance Binary   GetModIface
 
-
 data IsFileOfInterest = IsFileOfInterest
     deriving (Eq, Show, Typeable, Generic)
 instance Hashable IsFileOfInterest
 instance NFData   IsFileOfInterest
 instance Binary   IsFileOfInterest
+
+data GetModSummary = GetModSummary
+    deriving (Eq, Show, Typeable, Generic)
+instance Hashable GetModSummary
+instance NFData   GetModSummary
+instance Binary   GetModSummary

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -60,7 +60,6 @@ import           Development.IDE.GHC.Error
 import           Development.Shake                        hiding (Diagnostic)
 import Development.IDE.Core.RuleTypes
 import Development.IDE.Spans.Type
-import StringBuffer (hGetStringBuffer)
 
 import qualified GHC.LanguageExtensions as LangExt
 import HscTypes
@@ -519,10 +518,8 @@ getHiFileRule = defineEarlyCutoff $ \GetHiFile f -> do
 getModSummaryRule :: Rules ()
 getModSummaryRule = define $ \GetModSummary f -> do
     session <- hscEnv <$> use_ GhcSession f
-    let filePath = fromNormalizedFilePath f
     (_, mFileContent) <- getFileContents f
-    fileContent <- liftIO $ maybe (hGetStringBuffer filePath) (pure . textToStringBuffer) mFileContent
-    modS <- liftIO $ runExceptT $ getModSummaryFromImports (fromNormalizedFilePath f) fileContent session
+    modS <- liftIO $ runExceptT $ getModSummaryFromImports (fromNormalizedFilePath f) (textToStringBuffer <$> mFileContent) session
     return $ either (,Nothing) (([], ) . Just) modS
 
 getModIfaceRule :: Rules ()

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -61,11 +61,13 @@ import           Development.Shake                        hiding (Diagnostic)
 import Development.IDE.Core.RuleTypes
 import Development.IDE.Spans.Type
 import System.FilePath (takeFileName)
+import StringBuffer (hGetStringBuffer)
 
 import qualified GHC.LanguageExtensions as LangExt
 import HscTypes
 import DynFlags (xopt, thisPackage)
 import GHC.Generics(Generic)
+import Finder (mkHomeModLocation)
 import HeaderInfo (getImports)
 
 import qualified Development.IDE.Spans.AtPoint as AtPoint
@@ -460,14 +462,11 @@ getHiFileRule = defineEarlyCutoff $ \GetHiFile f -> do
   session <- hscEnv <$> use_ GhcSession f
   -- get all dependencies interface files, to check for freshness
   (deps,_) <- use_ GetLocatedImports f
+
   depHis  <- traverse (use GetHiFile) (mapMaybe (fmap artifactFilePath . snd) deps)
 
-  -- TODO find the hi file without relying on the parsed module
-  --      it should be possible to construct a ModSummary parsing just the imports
-  --      (see HeaderInfo in the GHC package)
-  pm      <- use_ GetParsedModule f
-  let hiFile = toNormalizedFilePath' $
-            case ms_hsc_src ms of
+  ms <- use_ GetModSummary f
+  let hiFile = case ms_hsc_src ms of
                 HsBootFile -> addBootSuffix (ml_hi_file $ ms_location ms)
                 _ -> ml_hi_file $ ms_location ms
       ms     = pm_mod_summary pm
@@ -503,6 +502,7 @@ getHiFileRule = defineEarlyCutoff $ \GetHiFile f -> do
               let d = mkInterfaceFilesGenerationDiag f "Stale interface file"
               pure (Nothing, (d, Nothing))
             else do
+              session <- hscEnv <$> use_ GhcSession f
               r <- liftIO $ loadInterface session ms deps
               case r of
                 Right iface -> do
@@ -516,54 +516,52 @@ getHiFileRule = defineEarlyCutoff $ \GetHiFile f -> do
 failRule :: IdeResult a
 failRule = ([], Nothing)
 
+logStr :: String -> Action ()
+logStr t = do
+    logger <- actionLogger
+    liftIO $ logDebug logger $ T.pack t
+
 getModSummaryRule :: Rules ()
 getModSummaryRule = define $ \GetModSummary f -> do
     session <- hscEnv <$> use_ GhcSession f
-    let
-        dflags = hsc_dflags session
+    let dflags = hsc_dflags session
         filePath = fromNormalizedFilePath f
         fileName = takeFileName filePath
-
     (_, mFileContent) <- getFileContents f
-    case mFileContent of
-        Nothing -> return failRule
-        Just fileContent -> do
-            eImports <- liftIO $ getImports dflags fileContent fileName fileName
-
-            case eImports of
-                Left err -> return failRule
-                Right (srcImports, normalImports, L _ moduleName) -> do
-                    modLoc <- liftIO $ mkHomeModLocation dflags moduleName fileName
-                    hieFileVersion  <- use_ GetModificationTime $ toNormalizedFilePath $ ml_hie_file modLoc
-                    let hieDate =
-                            case hieFileVersion  of
-                                VFSVersion v ->
-                                    error "HIE file shouldn't be in the virtual file system"
-
-                                ModificationTime l s ->
-                                    UTCTime
-                                        (ModifiedJulianDay $ fromIntegral l)
-                                        (picosecondsToDiffTime $ fromIntegral s)
-
-                    let mod = mkModule (thisPackage dflags) moduleName
-
-                        summary =
-                            ModSummary
-                                {  ms_mod          = mod
-                                ,  ms_hsc_src      = error "Should not depend on ms_iface_date"
-                                ,  ms_location     = modLoc
-                                ,  ms_hs_date      = error "Should not depend on ms_hs_date"
-                                ,  ms_obj_date     = error "Should not depend on ms_obj_date"
-                                ,  ms_iface_date   = error "Should not depend on ms_iface_date"
-                                ,  ms_hie_date     = Just hieDate
-                                ,  ms_srcimps      = srcImports
-                                ,  ms_textual_imps = normalImports -- Are normal imports == Non-source impors?
-                                ,  ms_parsed_mod   = error "Should not depend on ms_parsed_mod"
-                                ,  ms_hspp_file    = error "Should not depend on ms_hspp_file"
-                                ,  ms_hspp_opts    = dflags
-                                ,  ms_hspp_buf     = error "Should not depend on ms_hspp_buf"
-                               }
-                    return ([], Just summary)
+    fileContent <- liftIO $ maybe (hGetStringBuffer filePath) return mFileContent
+    eImports <- liftIO $ getImports dflags fileContent fileName fileName
+    case eImports of
+        Left _ -> do
+            logStr $ "Unable to get file imports for " <> filePath
+            return failRule
+        Right (srcImports, _, L _ moduleName) -> do
+            modLoc <- liftIO $ mkHomeModLocation dflags moduleName fileName
+            hieFileVersion  <- use_ GetModificationTime $ toNormalizedFilePath $ ml_hie_file modLoc
+            hieDate <- case hieFileVersion  of
+                VFSVersion _ -> error "HIE file shouldn't be in the virtual file system"
+                ModificationTime l s ->
+                    return $ UTCTime
+                        (ModifiedJulianDay $ fromIntegral l)
+                        (picosecondsToDiffTime $ fromIntegral s)
+            let mod = mkModule (thisPackage dflags) moduleName
+                summary =
+                    ModSummary
+                        {  ms_mod          = mod
+                        ,  ms_hsc_src      = HsSrcFile -- Will this always be true?
+                        ,  ms_location     = modLoc
+                        ,  ms_hs_date      = error "Should not depend on ms_hs_date"
+                        ,  ms_obj_date     = error "Should not depend on ms_obj_date"
+                        ,  ms_iface_date   = error "Should not depend on ms_iface_date"
+                        ,  ms_hie_date     = Just hieDate
+                        ,  ms_srcimps      = srcImports
+                        ,  ms_textual_imps = [] -- Are normal imports == Non-source impors?
+                        ,  ms_parsed_mod   = error "Should not depend on ms_parsed_mod"
+                        ,  ms_hspp_file    = error "Should not depend on ms_hspp_file"
+                        ,  ms_hspp_opts    = dflags
+                        ,  ms_hspp_buf     = error "Should not depend on ms_hspp_buf"
+                       }
+            logStr $ "Created ModSummary for " <> fromNormalizedFilePath f
+            return ([], Just summary)
 
 
 getModIfaceRule :: Rules ()
@@ -615,3 +613,4 @@ mainRule = do
     getHiFileRule
     getModIfaceRule
     isFileOfInterestRule
+    getModSummaryRule

--- a/src/Development/IDE/GHC/Error.hs
+++ b/src/Development/IDE/GHC/Error.hs
@@ -9,6 +9,7 @@ module Development.IDE.GHC.Error
   , diagFromStrings
   , diagFromGhcException
   , catchSrcErrors
+  , mergeDiagnostics
 
   -- * utilities working with spans
   , srcSpanToLocation
@@ -62,6 +63,25 @@ diagFromErrMsg diagSource dflags e =
 diagFromErrMsgs :: T.Text -> DynFlags -> Bag ErrMsg -> [FileDiagnostic]
 diagFromErrMsgs diagSource dflags = concatMap (diagFromErrMsg diagSource dflags) . bagToList
 
+-- | Merges two sorted lists of diagnostics, removing duplicates.
+--   Assumes all the diagnostics are for the same file.
+mergeDiagnostics :: [FileDiagnostic] -> [FileDiagnostic] -> [FileDiagnostic]
+mergeDiagnostics aa [] = aa
+mergeDiagnostics [] bb = bb
+mergeDiagnostics (a@(_,_,ad@Diagnostic{_range = ar}):aa) (b@(_,_,bd@Diagnostic{_range=br}):bb)
+  | ar < br
+  = a : mergeDiagnostics aa (b:bb)
+  | br < ar
+  = b : mergeDiagnostics (a:aa) bb
+  | _severity ad == _severity bd
+  && _source ad == _source bd
+  && _message ad == _message bd
+  && _code ad == _code bd
+  && _relatedInformation ad == _relatedInformation bd
+  && _tags ad == _tags bd
+  = a : mergeDiagnostics aa bb
+  | otherwise
+  = a : b : mergeDiagnostics aa bb
 
 -- | Convert a GHC SrcSpan to a DAML compiler Range
 srcSpanToRange :: SrcSpan -> Range

--- a/src/Development/IDE/GHC/Error.hs
+++ b/src/Development/IDE/GHC/Error.hs
@@ -36,6 +36,7 @@ import Panic
 import           ErrUtils
 import           SrcLoc
 import qualified Outputable                 as Out
+import Exception (ExceptionMonad)
 
 
 
@@ -128,7 +129,7 @@ realSpan = \case
 
 -- | Run something in a Ghc monad and catch the errors (SourceErrors and
 -- compiler-internal exceptions like Panic or InstallationError).
-catchSrcErrors :: GhcMonad m => T.Text -> m a -> m (Either [FileDiagnostic] a)
+catchSrcErrors :: (HasDynFlags m, ExceptionMonad m) => T.Text -> m a -> m (Either [FileDiagnostic] a)
 catchSrcErrors fromWhere ghcM = do
       dflags <- getDynFlags
       handleGhcException (ghcExceptionToDiagnostics dflags) $

--- a/src/Development/IDE/GHC/Orphans.hs
+++ b/src/Development/IDE/GHC/Orphans.hs
@@ -31,7 +31,7 @@ instance NFData Linkable where rnf = rwhnf
 instance Show InstalledUnitId where
     show = installedUnitIdString
 
-instance NFData InstalledUnitId where rnf = rwhnf
+instance NFData InstalledUnitId where rnf = rwhnf . installedUnitIdFS
 
 instance NFData SB.StringBuffer where rnf = rwhnf
 
@@ -40,8 +40,8 @@ instance Show Module where
 
 instance Show (GenLocated SrcSpan ModuleName) where show = prettyPrint
 
-instance NFData (GenLocated SrcSpan ModuleName) where
-    rnf = rwhnf
+instance (NFData l, NFData e) => NFData (GenLocated l e) where
+    rnf (L l e) = rnf l `seq` rnf e
 
 instance Show ModSummary where
     show = show . ms_mod
@@ -50,6 +50,9 @@ instance Show ParsedModule where
     show = show . pm_mod_summary
 
 instance NFData ModSummary where
+    rnf = rwhnf
+
+instance NFData FastString where
     rnf = rwhnf
 
 instance NFData ParsedModule where

--- a/src/Development/IDE/GHC/Util.hs
+++ b/src/Development/IDE/GHC/Util.hs
@@ -147,22 +147,20 @@ runGhcEnv env act = do
 -- | Given a module location, and its parse tree, figure out what is the include directory implied by it.
 --   For example, given the file @\/usr\/\Test\/Foo\/Bar.hs@ with the module name @Foo.Bar@ the directory
 --   @\/usr\/Test@ should be on the include path to find sibling modules.
-moduleImportPath :: NormalizedFilePath -> GHC.ParsedModule -> Maybe FilePath
+moduleImportPath :: NormalizedFilePath -> GHC.ModuleName -> Maybe FilePath
 -- The call to takeDirectory is required since DAML does not require that
 -- the file name matches the module name in the last component.
 -- Once that has changed we can get rid of this.
-moduleImportPath (takeDirectory . fromNormalizedFilePath -> pathDir) pm
+moduleImportPath (takeDirectory . fromNormalizedFilePath -> pathDir) mn
     -- This happens for single-component modules since takeDirectory "A" == "."
     | modDir == "." = Just pathDir
     | otherwise = dropTrailingPathSeparator <$> stripSuffix modDir pathDir
   where
-    ms   = GHC.pm_mod_summary pm
-    mod'  = GHC.ms_mod ms
     -- A for module A.B
     modDir =
         takeDirectory $
         fromNormalizedFilePath $ toNormalizedFilePath' $
-        moduleNameSlashes $ GHC.moduleName mod'
+        moduleNameSlashes mn
 
 -- | An 'HscEnv' with equality. Two values are considered equal
 --   if they are created with the same call to 'newHscEnvEq'.

--- a/src/Development/IDE/GHC/WithDynFlags.hs
+++ b/src/Development/IDE/GHC/WithDynFlags.hs
@@ -1,0 +1,30 @@
+module Development.IDE.GHC.WithDynFlags
+( WithDynFlags
+, evalWithDynFlags
+) where
+
+import Control.Monad.Trans.Reader (ask, ReaderT(..))
+import GHC (DynFlags)
+import Control.Monad.IO.Class (MonadIO)
+import Exception (ExceptionMonad(..))
+import Control.Monad.Trans.Class (MonadTrans(..))
+import GhcPlugins (HasDynFlags(..))
+
+-- | A monad transformer implementing the 'HasDynFlags' effect
+newtype WithDynFlags m a = WithDynFlags {withDynFlags :: ReaderT DynFlags m a}
+  deriving (Applicative, Functor, Monad, MonadIO, MonadTrans)
+
+evalWithDynFlags :: DynFlags -> WithDynFlags m a -> m a
+evalWithDynFlags dflags = flip runReaderT dflags . withDynFlags
+
+instance Monad m => HasDynFlags (WithDynFlags m) where
+    getDynFlags = WithDynFlags ask
+
+instance ExceptionMonad m => ExceptionMonad (WithDynFlags m) where
+    gmask f = WithDynFlags $ ReaderT $ \env ->
+        gmask $ \restore ->
+            let restore' = lift . restore . flip runReaderT env . withDynFlags
+            in runReaderT (withDynFlags $ f restore') env
+
+    gcatch (WithDynFlags act) handle = WithDynFlags $ ReaderT $ \env ->
+        gcatch (runReaderT act env) (flip runReaderT env . withDynFlags . handle)

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -1,6 +1,7 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE AllowAmbiguousTypes   #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE CPP #-}
@@ -12,7 +13,7 @@ import Control.Applicative.Combinators
 import Control.Exception (catch)
 import Control.Monad
 import Control.Monad.IO.Class (liftIO)
-import Data.Aeson (Value)
+import Data.Aeson (FromJSON, Value)
 import Data.Char (toLower)
 import Data.Foldable
 import Data.List
@@ -21,6 +22,7 @@ import qualified Data.Rope.UTF16 as Rope
 import Development.IDE.Core.PositionMapping (fromCurrent, toCurrent)
 import Development.IDE.GHC.Util
 import qualified Data.Text as T
+import Data.Typeable
 import Development.IDE.Spans.Common
 import Development.IDE.Test
 import Development.IDE.Test.Runfiles
@@ -436,24 +438,28 @@ watchedFilesTests :: TestTree
 watchedFilesTests = testGroup "watched files"
   [ testSession' "workspace files" $ \sessionDir -> do
       liftIO $ writeFile (sessionDir </> "hie.yaml") $ "cradle: {direct: {arguments: [\"-isrc\"]}}"
-      _ <- openDoc' "A.hs" "haskell" "{-#LANGUAGE NoImplicitPrelude #-}\nmodule A where\nimport B"
-      watchedFileRegs <- getWatchedFilesSubscriptionsUntilProgressEnd
+      _doc <- openDoc' "A.hs" "haskell" "{-#LANGUAGE NoImplicitPrelude #-}\nmodule A where\nimport WatchedFilesMissingModule"
+      watchedFileRegs <- getWatchedFilesSubscriptionsUntil @PublishDiagnosticsNotification
 
       -- Expect 6 subscriptions (A does not get any because it's VFS):
-      --  - /path-to-workspace/B.hs
-      --  - /path-to-workspace/B.lhs
-      --  - B.hs
-      --  - B.lhs
-      --  - src/B.hs
-      --  - src/B.lhs
+      --  - /path-to-workspace/WatchedFilesMissingModule.hs
+      --  - /path-to-workspace/WatchedFilesMissingModule.lhs
+      --  - WatchedFilesMissingModule.hs
+      --  - WatchedFilesMissingModule.lhs
+      --  - src/WatchedFilesMissingModule.hs
+      --  - src/WatchedFilesMissingModule.lhs
       liftIO $ length watchedFileRegs @?= 6
 
   , testSession' "non workspace file" $ \sessionDir -> do
       liftIO $ writeFile (sessionDir </> "hie.yaml") $ "cradle: {direct: {arguments: [\"-i/tmp\"]}}"
-      _ <- openDoc' "A.hs" "haskell" "{-# LANGUAGE NoImplicitPrelude#-}\nmodule A where\nimport B"
-      watchedFileRegs <- getWatchedFilesSubscriptionsUntilProgressEnd
+      _doc <- openDoc' "A.hs" "haskell" "{-# LANGUAGE NoImplicitPrelude#-}\nmodule A where\nimport WatchedFilesMissingModule"
+      watchedFileRegs <- getWatchedFilesSubscriptionsUntil @PublishDiagnosticsNotification
 
-      -- Expect 4 subscriptions:
+      -- Expect 4 subscriptions (/tmp does not get any as it is out of the workspace):
+      --  - /path-to-workspace/WatchedFilesMissingModule.hs
+      --  - /path-to-workspace/WatchedFilesMissingModule.lhs
+      --  - WatchedFilesMissingModule.hs
+      --  - WatchedFilesMissingModule.lhs
       liftIO $ length watchedFileRegs @?= 4
 
   -- TODO add a test for didChangeWorkspaceFolder
@@ -2323,9 +2329,9 @@ nthLine i r
     | i >= Rope.rows r = error $ "Row number out of bounds: " <> show i <> "/" <> show (Rope.rows r)
     | otherwise = Rope.takeWhile (/= '\n') $ fst $ Rope.splitAtLine 1 $ snd $ Rope.splitAtLine (i - 1) r
 
-getWatchedFilesSubscriptionsUntilProgressEnd :: Session [Maybe Value]
-getWatchedFilesSubscriptionsUntilProgressEnd = do
-      msgs <- manyTill (Just <$> message @RegisterCapabilityRequest <|> Nothing <$ anyMessage) (message @WorkDoneProgressEndNotification)
+getWatchedFilesSubscriptionsUntil :: forall end . (FromJSON end, Typeable end) => Session [Maybe Value]
+getWatchedFilesSubscriptionsUntil = do
+      msgs <- manyTill (Just <$> message @RegisterCapabilityRequest <|> Nothing <$ anyMessage) (message @end)
       return
             [ args
             | Just (RequestMessage{_params = RegistrationParams (List regs)}) <- msgs

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -412,6 +412,19 @@ diagnosticTests = testGroup "diagnostics"
           liftIO $ unless ("redundant" `T.isInfixOf` msg) $
               assertFailure ("Expected redundant import but got " <> T.unpack msg)
           closeDoc a
+  , testSessionWait "haddock parse error" $ do
+      let fooContent = T.unlines
+            [ "module Foo where"
+            , "foo :: Int"
+            , "foo = 1 {-|-}"
+            ]
+      _ <- openDoc' "Foo.hs" "haskell" fooContent
+      expectDiagnostics
+        [ ( "Foo.hs"
+          , [(DsError, (2, 8), "Parse error on input")
+            ]
+          )
+        ]
   ]
 
 codeActionTests :: TestTree


### PR DESCRIPTION
Instead of full modules, ghcide now parses only the module headers and avoids storing unnecessary ASTs in the Shake graph where possible. This happens in a couple of places:

* Locating the imports of a module. Now this uses a `ModSummary` instead of a `ParsedModule`
* For computing all the completions in a module. Now this uses a `ModIface` instead, i.e. a `.hi` file. 
* For computing source span infos, the parsed modules are only used when building against `ghc-lib`.  Otherwise, `ModIface` is used instead. 
* Interface files created by ghcide now embed Haddocks

Altogether, ghcide only parses full modules for files of interest now, or for dependencies when an up-to-date `.hi` file is not available. The main benefits are 
1. shorter start-up times 
2. lower memory usage. 

Joint work with @lazamar.

Fixes #505 