### PR TITLE
Improve ghc version check

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -192,7 +192,7 @@ executable ghcide
         directory,
         extra,
         filepath,
-        ghc-check >= 0.1.0.3,
+        ghc-check >= 0.3.0.1,
         ghc-paths,
         ghc,
         gitrev,

--- a/src/Development/IDE/GHC/Util.hs
+++ b/src/Development/IDE/GHC/Util.hs
@@ -167,7 +167,7 @@ moduleImportPath (takeDirectory . fromNormalizedFilePath -> pathDir) mn
 data HscEnvEq
     = HscEnvEq !Unique !HscEnv
     | GhcVersionMismatch { compileTime :: !Version
-                         , runTime     :: !(Maybe Version)
+                         , runTime     :: !Version
                          }
 
 -- | Unwrap an 'HsEnvEq'.
@@ -181,7 +181,7 @@ hscEnv' GhcVersionMismatch{..} = Left $
         ["ghcide compiled against GHC"
         ,showVersion compileTime
         ,"but currently using"
-        ,maybe "an unknown version of GHC" (\v -> "GHC " <> showVersion v) runTime
+        ,showVersion runTime
         ,". This is unsupported, ghcide must be compiled with the same GHC version as the project."
         ]
 

--- a/stack-ghc-lib.yaml
+++ b/stack-ghc-lib.yaml
@@ -13,7 +13,7 @@ extra-deps:
 - regex-base-0.94.0.0
 - regex-tdfa-1.3.1.0
 - haddock-library-1.8.0
-- ghc-check-0.1.0.3
+- ghc-check-0.3.0.1
 nix:
   packages: [zlib]
 flags:

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,6 +14,6 @@ extra-deps:
 - parser-combinators-1.2.1
 - haddock-library-1.8.0
 - tasty-rerun-1.1.17
-- ghc-check-0.1.0.3
+- ghc-check-0.3.0.1
 nix:
   packages: [zlib]

--- a/stack84.yaml
+++ b/stack84.yaml
@@ -22,8 +22,7 @@ extra-deps:
 - unordered-containers-0.2.10.0
 - file-embed-0.0.11.2
 - heaps-0.3.6.1
-- ghc-check-0.1.0.3
-
+- ghc-check-0.3.0.1
 # For tasty-retun
 - ansi-terminal-0.10.3
 - ansi-wl-pprint-0.6.9

--- a/stack88.yaml
+++ b/stack88.yaml
@@ -5,7 +5,6 @@ extra-deps:
 - haskell-lsp-0.21.0.0
 - haskell-lsp-types-0.21.0.0
 - lsp-test-0.10.2.0
-- ghc-check-0.1.0.3
-
+- ghc-check-0.3.0.1
 nix:
   packages: [zlib]


### PR DESCRIPTION
- retrieve runtime version from ghc executable, not from pkg db (ghc-check 0.3.0.0)
- Do not fail if unable to retrieve runtime version

Fixes #534 and #536 