### PR TITLE
Update README with link to Docker build for Neovim and ghcide

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ Add this to your coc-settings.json (which you can edit with :CocConfig):
 Here's a nice article on setting up neovim and coc: [Vim and Haskell in
 2019](http://marco-lopes.com/articles/Vim-and-Haskell-in-2019/)
 
+Here is a Docker container that pins down the build and configuration for
+Neovim and ghcide on a minimal Debian 10 base system:
+[docker-ghcide-neovim](https://github.com/carlohamalainen/docker-ghcide-neovim/).
+
 ### SpaceVim
 
 In the `autocomplete` layer, add the `autocomplete_method` option to force the use of `coc`:

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Add this to your coc-settings.json (which you can edit with :CocConfig):
 ```
 
 Here's a nice article on setting up neovim and coc: [Vim and Haskell in
-2019](http://marco-lopes.com/articles/Vim-and-Haskell-in-2019/)
+2019](http://marco-lopes.com/articles/Vim-and-Haskell-in-2019/) (this is actually for haskell-ide, not ghcide)
 
 Here is a Docker container that pins down the build and configuration for
 Neovim and ghcide on a minimal Debian 10 base system:


### PR DESCRIPTION
The README mentions a blog post by Marco Lopes from 2019 but I hit bugs or configuration issues at every step. For example Marco's guide says "set up coc.nvim" but doesn't provide the full ``coc-settings.json`` file, nor does it say where to put it. And the sample doesn't work with the current ``hie-wrapper`` (I got duplicate "starting..." messages and nothing happened).

In the interest of reproducibility I created a Dockerfile that builds ghcide, haskell-ide-engine, Neovim, and coc.nvim, configures each component, and sets up a hello-world project to confirm that everything works.