### PR TITLE
Fix 3 space leaks and refactoring of PositionMapping

### DIFF
--- a/src/Development/IDE/Core/PositionMapping.hs
+++ b/src/Development/IDE/Core/PositionMapping.hs
@@ -2,11 +2,15 @@
 -- SPDX-License-Identifier: Apache-2.0
 module Development.IDE.Core.PositionMapping
   ( PositionMapping(..)
+  , fromCurrentPosition
+  , toCurrentPosition
+  , PositionDelta(..)
+  , addDelta
+  , mkDelta
   , toCurrentRange
   , fromCurrentRange
   , applyChange
-  , composeMapping
-  , idMapping
+  , zeroMapping
   -- toCurrent and fromCurrent are mainly exposed for testing
   , toCurrent
   , fromCurrent
@@ -15,11 +19,24 @@ module Development.IDE.Core.PositionMapping
 import Control.Monad
 import qualified Data.Text as T
 import Language.Haskell.LSP.Types
+import Data.List
 
-data PositionMapping = PositionMapping
-  { toCurrentPosition :: !(Position -> Maybe Position)
-  , fromCurrentPosition :: !(Position -> Maybe Position)
+-- The position delta is the difference between two versions
+data PositionDelta = PositionDelta
+  { toDelta :: !(Position -> Maybe Position)
+  , fromDelta :: !(Position -> Maybe Position)
   }
+
+fromCurrentPosition :: PositionMapping -> Position -> Maybe Position
+fromCurrentPosition (PositionMapping pm) = fromDelta pm
+
+toCurrentPosition :: PositionMapping -> Position -> Maybe Position
+toCurrentPosition (PositionMapping pm) = toDelta pm
+
+-- A position mapping is the difference from the current version to
+-- a specific version
+newtype PositionMapping = PositionMapping PositionDelta
+
 
 toCurrentRange :: PositionMapping -> Range -> Maybe Range
 toCurrentRange mapping (Range a b) =
@@ -29,20 +46,33 @@ fromCurrentRange :: PositionMapping -> Range -> Maybe Range
 fromCurrentRange mapping (Range a b) =
     Range <$> fromCurrentPosition mapping a <*> fromCurrentPosition mapping b
 
-idMapping :: PositionMapping
-idMapping = PositionMapping Just Just
+zeroMapping :: PositionMapping
+zeroMapping = PositionMapping idDelta
 
 -- | Compose two position mappings. Composes in the same way as function
 -- composition (ie the second argument is applyed to the position first).
-composeMapping :: PositionMapping -> PositionMapping -> PositionMapping
-composeMapping (PositionMapping to1 from1) (PositionMapping to2 from2) =
-  PositionMapping (to1 <=< to2)
-                  (from1 >=> from2)
+composeDelta :: PositionDelta
+                -> PositionDelta
+                -> PositionDelta
+composeDelta (PositionDelta to1 from1) (PositionDelta to2 from2) =
+  PositionDelta (to1 <=< to2)
+                (from1 >=> from2)
 
-applyChange :: PositionMapping -> TextDocumentContentChangeEvent -> PositionMapping
-applyChange PositionMapping{..} (TextDocumentContentChangeEvent (Just r) _ t) = PositionMapping
-    { toCurrentPosition = \x -> toCurrent r t =<< toCurrentPosition x
-    , fromCurrentPosition = \x -> fromCurrentPosition  =<< fromCurrent r t x
+idDelta :: PositionDelta
+idDelta = PositionDelta Just Just
+
+-- | Convert a set of changes into a delta from k  to k + 1
+mkDelta :: [TextDocumentContentChangeEvent] -> PositionDelta
+mkDelta cs = foldl' applyChange idDelta cs
+
+-- | Add a new delta onto a Mapping k n to make a Mapping (k - 1) n
+addDelta :: PositionDelta -> PositionMapping -> PositionMapping
+addDelta delta (PositionMapping pm) = PositionMapping (composeDelta delta pm)
+
+applyChange :: PositionDelta -> TextDocumentContentChangeEvent -> PositionDelta
+applyChange PositionDelta{..} (TextDocumentContentChangeEvent (Just r) _ t) = PositionDelta
+    { toDelta = toCurrent r t <=< toDelta
+    , fromDelta = fromDelta <=< fromCurrent r t
     }
 applyChange posMapping _ = posMapping
 

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -536,7 +536,7 @@ usesWithStale key files = do
 
 withProgress :: (Eq a, Hashable a) => Var (HMap.HashMap a Int) -> a -> Action b -> Action b
 withProgress var file = actionBracket (f succ) (const $ f pred) . const
-    where f shift = modifyVar_ var $ return . HMap.alter (Just . shift . fromMaybe 0) file
+    where f shift = modifyVar_ var $ \x -> return (HMap.alter (Just . shift . fromMaybe 0) file x)
 
 
 defineEarlyCutoff

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -97,9 +97,11 @@ data ShakeExtras = ShakeExtras
     ,publishedDiagnostics :: Var (HMap.HashMap NormalizedUri [Diagnostic])
     -- ^ This represents the set of diagnostics that we have published.
     -- Due to debouncing not every change might get published.
-    ,positionMapping :: Var (HMap.HashMap NormalizedUri (Map TextDocumentVersion PositionMapping))
+    ,positionMapping :: Var (HMap.HashMap NormalizedUri (Map TextDocumentVersion (PositionMapping, PositionMapping)))
     -- ^ Map from a text document version to a PositionMapping that describes how to map
     -- positions in a version of that document to positions in the latest version
+    -- First mapping is delta from previous version and second one is an
+    -- accumlation of all previous mappings.
     ,inProgress :: Var (HMap.HashMap NormalizedFilePath Int)
     -- ^ How many rules are running for each file
     }
@@ -201,12 +203,12 @@ valueVersion = \case
     Failed -> Nothing
 
 mappingForVersion
-    :: HMap.HashMap NormalizedUri (Map TextDocumentVersion PositionMapping)
+    :: HMap.HashMap NormalizedUri (Map TextDocumentVersion (a, PositionMapping))
     -> NormalizedFilePath
     -> TextDocumentVersion
     -> PositionMapping
 mappingForVersion allMappings file ver =
-    fromMaybe idMapping $
+    maybe idMapping snd $
     Map.lookup ver =<<
     HMap.lookup (filePathToUri' file) allMappings
 
@@ -832,7 +834,13 @@ updatePositionMapping IdeState{shakeExtras = ShakeExtras{positionMapping}} Versi
     modifyVar_ positionMapping $ \allMappings -> do
         let uri = toNormalizedUri _uri
         let mappingForUri = HMap.lookupDefault Map.empty uri allMappings
-        let updatedMapping =
-                Map.insert _version idMapping $
-                Map.map (\oldMapping -> foldl' applyChange oldMapping changes) mappingForUri
+        let (_, updatedMapping) =
+                -- Very important to use mapAccum here so that the tails of
+                -- each mapping can be shared, otherwise quadratic space is
+                -- used which is evident in long running sessions.
+                Map.mapAccumRWithKey (\acc _k (delta, _) -> let new = composeMapping delta acc in (new, (delta, acc)))
+                  idMapping
+                  (Map.insert _version (shared_change, idMapping) mappingForUri)
         pure $! HMap.insert uri updatedMapping allMappings
+  where
+    shared_change = foldl' applyChange idMapping changes

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -538,6 +538,9 @@ usesWithStale key files = do
 
 withProgress :: (Eq a, Hashable a) => Var (HMap.HashMap a Int) -> a -> Action b -> Action b
 withProgress var file = actionBracket (f succ) (const $ f pred) . const
+    -- This functions are deliberately eta-expanded to avoid space leaks.
+    -- Do not remove the eta-expansion without profiling a session with at
+    -- least 1000 modifications.
     where f shift = modifyVar_ var $ \x -> return (HMap.alter (\x -> Just (shift (fromMaybe 0 x))) file x)
 
 

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -538,7 +538,7 @@ usesWithStale key files = do
 
 withProgress :: (Eq a, Hashable a) => Var (HMap.HashMap a Int) -> a -> Action b -> Action b
 withProgress var file = actionBracket (f succ) (const $ f pred) . const
-    where f shift = modifyVar_ var $ \x -> return (HMap.alter (Just . shift . fromMaybe 0) file x)
+    where f shift = modifyVar_ var $ \x -> return (HMap.alter (\x -> Just (shift (fromMaybe 0 x))) file x)
 
 
 defineEarlyCutoff


### PR DESCRIPTION
Please review this commit by commit. 

The first three commits are just about fixing space leaks.

The fourth commit is a comment warning about not unfixing the leak.

The fifth commit is a refactoring which makes the correctness of the first commit more obvious but seemed distracting to include in the same commit. 