### PR TITLE
Upgrade to lsp-test-0.11

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -263,7 +263,7 @@ test-suite ghcide-tests
         haskell-lsp-types,
         network-uri,
         lens,
-        lsp-test >= 0.8,
+        lsp-test >= 0.11.0.1 && < 0.12,
         parser-combinators,
         QuickCheck,
         quickcheck-instances,

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@ packages:
 extra-deps:
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
-- lsp-test-0.10.3.0
+- lsp-test-0.11.0.1
 - hie-bios-0.4.0
 - fuzzy-0.1.0.0
 - regex-pcre-builtin-0.95.1.1.8.43

--- a/stack810.yaml
+++ b/stack810.yaml
@@ -6,7 +6,7 @@ packages:
 extra-deps:
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
-- lsp-test-0.10.3.0
+- lsp-test-0.11.0.1
 - ghc-check-0.3.0.1
 
 # for ghc-8.10

--- a/stack84.yaml
+++ b/stack84.yaml
@@ -7,7 +7,7 @@ extra-deps:
 - base-orphans-0.8.2
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
-- lsp-test-0.10.3.0
+- lsp-test-0.11.0.1
 - rope-utf16-splay-0.3.1.0
 - filepattern-0.1.1
 - js-dgtable-0.5.2

--- a/stack88.yaml
+++ b/stack88.yaml
@@ -4,7 +4,7 @@ packages:
 extra-deps:
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
-- lsp-test-0.10.3.0
+- lsp-test-0.11.0.1
 - ghc-check-0.3.0.1
 
 nix:

--- a/test/src/Development/IDE/Test.hs
+++ b/test/src/Development/IDE/Test.hs
@@ -19,7 +19,7 @@ import Control.Monad.IO.Class
 import           Data.Foldable
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
-import Language.Haskell.LSP.Test hiding (message, openDoc')
+import Language.Haskell.LSP.Test hiding (message)
 import qualified Language.Haskell.LSP.Test as LspTest
 import Language.Haskell.LSP.Types
 import Language.Haskell.LSP.Types.Lens as Lsp


### PR DESCRIPTION
lsp-test-0.11 has replaced openDoc' with createDoc which sends out workspace/didChangedWatchedFiles notifications, so the wrapper in https://github.com/digital-asset/ghcide/pull/322 shouldn't be needed anymore