### PR TITLE
Log cache dir

### DIFF
--- a/exe/Rules.hs
+++ b/exe/Rules.hs
@@ -38,6 +38,7 @@ import qualified Language.Haskell.LSP.Types     as LSP
 import Data.Aeson (ToJSON(toJSON))
 import Development.IDE.Types.Logger (logDebug)
 import Util
+import System.IO (hPutStrLn, stderr)
 
 -- Prefix for the cache path
 cacheDir :: String
@@ -121,6 +122,8 @@ createSession (ComponentOptions theOpts _) = do
     libdir <- getLibdir
 
     cacheDir <- getCacheDir theOpts
+
+    hPutStrLn stderr $ "Interface files cache dir: " <> cacheDir
 
     runGhc (Just libdir) $ do
         dflags <- getSessionDynFlags


### PR DESCRIPTION
Sometimes one needs to clear up the cache dir manually, e.g. if GHC is unable to detect that the interface files are stale and need rebuilding. This change is aimed at making the discovery of the cache dir location a bit easier. There are two changes

1. Log the cache dir location at startup,
2. Make the cache dir local to the project, as not every lsp client makes it easy to retrieve the lsp server logs 