### PR TITLE
Overhaul ghc api initialization error handling

### DIFF
--- a/exe/Rules.hs
+++ b/exe/Rules.hs
@@ -8,7 +8,7 @@ module Rules
   )
 where
 
-import           Control.Exception
+import           Control.Exception.Safe
 import           Control.Monad                  (filterM, when)
 import qualified Crypto.Hash.SHA1               as H
 import           Data.ByteString.Base16         (encode)
@@ -22,7 +22,6 @@ import           Development.IDE.GHC.Util
 import           Development.IDE.Types.Location (fromNormalizedFilePath)
 import           Development.IDE.Types.Options  (IdeOptions(IdeOptions, optTesting))
 import           Development.Shake
-import           Exception                      (gtry)
 import           GHC
 import           GHC.Check                      (GhcVersionChecker, InstallationCheck(..), PackageMismatch(..), makeGhcVersionChecker)
 import           HIE.Bios
@@ -130,7 +129,7 @@ createSession (ComponentOptions theOpts _) = do
               -- Setting up the cradle options in the ghc session can fail
               -- if --package-id options cannot be satisfied due to ghc
               -- version mismatches
-              sessionSetupResult <- gtry $ do
+              sessionSetupResult <- gtrySafe $ do
                 dflags <- getSessionDynFlags
                 (dflags', _targets) <- addCmdOpts theOpts dflags
                 setupDynFlags cacheDir dflags'
@@ -141,7 +140,7 @@ createSession (ComponentOptions theOpts _) = do
                 Right () -> do
                     -- Even if all the cradle options were installed successfully,
                     -- we still need to check the user package versions
-                    versionMismatch <- gtry ghcLibCheck
+                    versionMismatch <- gtrySafe ghcLibCheck
 
                     case versionMismatch of
                         Right (Just (packageName, VersionMismatch{..})) ->

--- a/exe/Rules.hs
+++ b/exe/Rules.hs
@@ -122,7 +122,7 @@ createSession (ComponentOptions theOpts _) = do
     --   - version mismatches
     case installationCheck of
         InstallationNotFound{..} ->
-            error $ "GHC installation not found in libdir: " <> libdir
+            fail $ "GHC installation not found in libdir: " <> libdir
         InstallationMismatch{..} ->
             return GhcVersionMismatch{..}
         InstallationChecked installationVersion ghcLibCheck ->

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -197,7 +197,7 @@ executable ghcide
         directory,
         extra,
         filepath,
-        ghc-check >= 0.3.0.1 && < 0.4,
+        ghc-check >= 0.4 && < 0.5,
         ghc-paths,
         ghc,
         gitrev,

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -207,6 +207,7 @@ executable ghcide
         hie-bios >= 0.4.0 && < 0.5,
         ghcide,
         optparse-applicative,
+        safe-exceptions,
         shake,
         text,
         unordered-containers

--- a/src/Development/IDE/GHC/Util.hs
+++ b/src/Development/IDE/GHC/Util.hs
@@ -193,24 +193,24 @@ hscEnv = either error id . hscEnv'
 hscEnv' :: HscEnvEq -> Either String HscEnv
 hscEnv' (HscEnvEq _ x) = Right x
 hscEnv' GhcInitializationError{compileTime, message} = Left $ unwords
-    [ "ghcide compiled by GHC ", showVersion compileTime
-    , "failed to load packages:", message
-    , ". Please ensure that ghci is compiled with the same GHC installation as the project."]
+    [ "ghcide compiled by GHC", showVersion compileTime
+    , "failed to load packages:", message <> "."
+    , "Please ensure that ghci is compiled with the same GHC installation as the project."]
 hscEnv' GhcVersionMismatch{..} = Left $
     unwords
         ["ghcide compiled by GHC"
         ,showVersion compileTime
         ,"but currently using"
-        ,showVersion runTime
-        ,". This is unsupported, ghcide must be compiled with the same GHC installation as the project."
+        ,showVersion runTime <> "."
+        ,"This is unsupported, ghcide must be compiled with the same GHC installation as the project."
         ]
 hscEnv' PackageVersionMismatch{..} = Left $
     unwords
-        ["ghcide compiled with package "
+        ["ghcide compiled with package"
         , packageName <> "-" <> showVersion compileTime
         ,"but project uses package"
-        , packageName <> "-" <> showVersion runTime
-        ,". This is unsupported, ghcide must be compiled with the same GHC installation as the project."
+        , packageName <> "-" <> showVersion runTime <> "."
+        ,"This is unsupported, ghcide must be compiled with the same GHC installation as the project."
         ]
 
 hscEnv' PackageAbiMismatch{..} = Left $
@@ -220,8 +220,8 @@ hscEnv' PackageAbiMismatch{..} = Left $
         , "and abi"
         , compileTimeAbi
         ,"but project has abi"
-        , runTimeAbi
-        ,". This is unsupported, ghcide must be compiled with the same GHC installation as the project."
+        , runTimeAbi <> "."
+        ,"This is unsupported, ghcide must be compiled with the same GHC installation as the project."
         ]
 
 

--- a/stack-ghc-lib.yaml
+++ b/stack-ghc-lib.yaml
@@ -13,7 +13,7 @@ extra-deps:
 - regex-base-0.94.0.0
 - regex-tdfa-1.3.1.0
 - haddock-library-1.8.0
-- ghc-check-0.3.0.1
+- ghc-check-0.4.0.0
 nix:
   packages: [zlib]
 flags:

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,6 +14,6 @@ extra-deps:
 - parser-combinators-1.2.1
 - haddock-library-1.8.0
 - tasty-rerun-1.1.17
-- ghc-check-0.3.0.1
+- ghc-check-0.4.0.0
 nix:
   packages: [zlib]

--- a/stack810.yaml
+++ b/stack810.yaml
@@ -7,7 +7,7 @@ extra-deps:
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
 - lsp-test-0.11.0.1
-- ghc-check-0.3.0.1
+- ghc-check-0.4.0.0
 
 # for ghc-8.10
 - Cabal-3.2.0.0

--- a/stack84.yaml
+++ b/stack84.yaml
@@ -22,7 +22,7 @@ extra-deps:
 - unordered-containers-0.2.10.0
 - file-embed-0.0.11.2
 - heaps-0.3.6.1
-- ghc-check-0.3.0.1
+- ghc-check-0.4.0.0
 # For tasty-retun
 - ansi-terminal-0.10.3
 - ansi-wl-pprint-0.6.9

--- a/stack88.yaml
+++ b/stack88.yaml
@@ -5,7 +5,7 @@ extra-deps:
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
 - lsp-test-0.11.0.1
-- ghc-check-0.3.0.1
+- ghc-check-0.4.0.0
 
 nix:
   packages: [zlib]


### PR DESCRIPTION
There are really a lot of cases to handle as seen below. Thanks
@jneira for help discovering them all.

Non Nix
=========

The table below shows a couple of combinations of cradles and ghcide versions in a
non-Nix environment. All the version mismatches are now handled as follows:

- "Cannot satisfy package" - arises due to `-package-id` flags referencing
  dependencies bundled in another ghc version
- "version-check" - detected by ghc-check using either the version of the "ghc"
  package or the abi of the base package
- "linker error" - arises due to missing symbols in the "ghc-prim" package when
  loading an incompatible version

cradle/ghcide | 8.6 | 8.8 | 8.10
--------------|-----|----|---
Cabal 8.6   | success | cannot satisfy package | cannot satisfy package
Cabal 8.8   | cannot satisfy package | success | cannot satisfy package
Cabal 8.10  | cannot satisfy package | cannot satisfy package | success
Stack 8.6   | success | linker error | version-check
Stack 8.8   | version-check | success | version-check
Stack 8.10  | version-check | version-check | success

Nix
=========

Because Nix redefines the libdir to point at the run-time ghc installation, all
the invalid combinations in the table above are detected by the "installation
check" performed by ghc-check.