### PR TITLE
Remove space leaks in a more robust way

### DIFF
--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -541,7 +541,7 @@ withProgress var file = actionBracket (f succ) (const $ f pred) . const
     -- This functions are deliberately eta-expanded to avoid space leaks.
     -- Do not remove the eta-expansion without profiling a session with at
     -- least 1000 modifications.
-    where f shift = modifyVar_ var $ \x -> return (HMap.alter (\x -> Just (shift (fromMaybe 0 x))) file x)
+    where f shift = modifyVar_ var $ \x -> evaluate $ HMap.alter (\x -> Just $! shift (fromMaybe 0 x)) file x
 
 
 defineEarlyCutoff


### PR DESCRIPTION
Follow up from #557. We definitely want the progress state to be fully evaluated, so demand that with evaluating functions like evaluate and $!, rather than relying on the compiler to get it right. My guess is the `$!` is unnecessary now we have `evaluate`, but it's also not harmful, so belt and braces approach.