### PR TITLE
Avoid deprecated Shake functions

### DIFF
--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -743,7 +743,7 @@ publishDiagnosticsNotification uri diags =
 newtype Priority = Priority Double
 
 setPriority :: Priority -> Action ()
-setPriority (Priority p) = deprioritize p
+setPriority (Priority p) = reschedule p
 
 sendEvent :: LSP.FromServerMessage -> Action ()
 sendEvent e = do


### PR DESCRIPTION
In 0.18.4 deprioritize was renamed reschedule, so follow the new name.