### PR TITLE
Make VFSVersion strict

### DIFF
--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -769,7 +769,7 @@ instance Binary   GetModificationTime
 type instance RuleResult GetModificationTime = FileVersion
 
 data FileVersion
-    = VFSVersion Int
+    = VFSVersion !Int
     | ModificationTime
       !Int   -- ^ Large unit (platform dependent, do not make assumptions)
       !Int   -- ^ Small unit (platform dependent, do not make assumptions)


### PR DESCRIPTION
When debugging for space leaks this stood out as weird - an ADT where some alternatives are strict in their fields, and some aren't. I don't think it has any impact, but seems the right way to go.