### PR TITLE
Remove a space leak in setValues

### DIFF
--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -259,7 +259,7 @@ setValues :: IdeRule k v
 setValues state key file val = modifyVar_ state $ \vals -> do
     -- Force to make sure the old HashMap is not retained
     let v = fmap toDyn val
-    evaluate v
+    _ <- evaluate v
     let k = (file, Key key)
     res <- evaluate $ HMap.insert k v vals
 


### PR DESCRIPTION
The comment in the code describes it best. I would have assumed unordered-containers gets this right. But, with a repeatedly hover and don't edit, I get 30Mb/min leak. If I change below, I get no leak. If I do anything without the second lookup/evaluate pair, the leak doesn't go away. I tried to reproduce this bug with unordered-containers on its own, and failed. I'm completely lost, but I do have a fix.