### PR TITLE
Fix the Hashable instance of Key

### DIFF
--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -156,7 +156,7 @@ instance Eq Key where
                      | otherwise = False
 
 instance Hashable Key where
-    hashWithSalt salt (Key key) = hashWithSalt salt key
+    hashWithSalt salt (Key key) = hashWithSalt salt (typeOf key, key)
 
 -- | The result of an IDE operation. Warnings and errors are in the Diagnostic,
 --   and a value is in the Maybe. For operations that throw an error you


### PR DESCRIPTION
Before we hashed all unary constructors (e.g. DoesFileExists, GetModificationTime) to the same constant (via the Generic Hashable instance), and thus treated these keys as all equivalent, and thus got tons of hash collisions, and thus got space leaks via https://github.com/tibbe/unordered-containers/issues/254. Much better to _not_ have hash collisions or space leaks, which we do by hashing in the type, like Shake does.

While writing this patch my first approach was to copy Shake, which does `hashWithSalt salt type 'xor' hashWithSalt salt value`. That is terrible because `(,)` uses `hashWithSalt` to merge the pair together, and if you xor two salts that have been xor'd you end up cancelling them out, and go back to collisions galore. I'm going to go fix Shake (I don't think it matters because of how I happy to use it, but might as well get it right). But it's also much easier to just use the pair instance that gets this right.

I also looked at haskell-lsp-types, and realised their hashWithSalt method was a generic one which skips all their optimisations, so once that fix lands, we might get a perf benefit. https://github.com/alanz/haskell-lsp/pull/248

With this patch I get zero collisions and no space leak. Yay!