### PR TITLE
remove unnecessary FileExists dependency in GetHiFile

### DIFF
--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -52,7 +52,6 @@ import           Data.Foldable
 import qualified Data.IntMap.Strict as IntMap
 import Data.IntMap.Strict (IntMap)
 import Data.List
-import Data.Ord
 import qualified Data.Set                                 as Set
 import qualified Data.Text                                as T
 import           Development.IDE.GHC.Error
@@ -76,6 +75,8 @@ import Data.ByteString (ByteString)
 import Control.Concurrent.Async (concurrently)
 
 import Control.Monad.State
+import System.IO.Error (isDoesNotExistError)
+import Control.Exception.Safe (IOException, catch)
 
 -- | This is useful for rules to convert rules that can only produce errors or
 -- a result into the more general IdeResult type that supports producing
@@ -136,22 +137,24 @@ getHieFile file mod = do
     _ -> getPackageHieFile mod file
 
 
-getHomeHieFile :: NormalizedFilePath -> Action ([a], Maybe HieFile)
+getHomeHieFile :: NormalizedFilePath -> Action ([IOException], Maybe HieFile)
 getHomeHieFile f = do
   ms <- use_ GetModSummary f
-  let normal_hie_f = toNormalizedFilePath' hie_f
-      hie_f = ml_hie_file $ ms_location ms
-  mbHieTimestamp <- use GetModificationTime normal_hie_f
-  srcTimestamp   <- use_ GetModificationTime f
-  let isUpToDate
-        | Just d <- mbHieTimestamp = comparing modificationTime d srcTimestamp == GT
-        | otherwise = False
 
-  unless isUpToDate $
-       void $ use_ TypeCheck f
+  -- .hi and .hie files are generated as a byproduct of typechecking.
+  -- To avoid duplicating staleness checking already performed for .hi files,
+  -- we overapproximate here by depending on the GetModIface rule.
+  hiFile  <- use GetModIface f
 
-  hf <- liftIO $ whenMaybe isUpToDate (loadHieFile hie_f)
-  return ([], hf)
+  case hiFile of
+    Nothing -> return ([], Nothing)
+    Just _ -> liftIO $ do
+        hf <- loadHieFile $ ml_hie_file $ ms_location ms
+        return ([], Just hf)
+      `catch` \e ->
+        if isDoesNotExistError e
+            then return ([], Nothing)
+            else return ([e], Nothing)
 
 getPackageHieFile :: Module             -- ^ Package Module to load .hie file for
                   -> NormalizedFilePath -- ^ Path of home module importing the package module


### PR DESCRIPTION
It is subsumed by the GetModificationTime dependency.

One less dependency per .hi file,
one less redundant file system access,
five fewer lines of code.

This does *not* implement all the improvements discussed in #583, it's just a minor efficiency fix.

I have not measured the performance impact either, since there is no easy-to-run standard benchmark, but I expect the impact to be very small.