### PR TITLE
Benchmark suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cabal.project.local
 /.tasty-rerun-log
 .vscode
 /.hlint-*
+bench/example

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -73,7 +73,6 @@
   - {name: ViewPatterns, within: []}
 
   # Shady extensions
-  - {name: ImplicitParams, within: []}
   - name: CPP
     within:
     - Development.IDE.Compat

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -1,0 +1,192 @@
+{- An automated benchmark built around the simple experiment described in:
+
+  > https://neilmitchell.blogspot.com/2020/05/fixing-space-leaks-in-ghcide.html
+
+  As an example project, it unpacks Cabal-3.2.0.0 in the local filesystem and
+  loads the module 'Distribution.Simple'. The rationale for this choice is:
+
+    - It's convenient to download with `cabal unpack Cabal-3.2.0.0`
+    - It has very few dependencies, and all are already needed to build ghcide
+    - Distribution.Simple has 235 transitive module dependencies, so non trivial
+
+  The experiments are sequences of lsp commands scripted using lsp-test.
+  A more refined approach would be to record and replay real IDE interactions,
+  once the replay functionality is available in lsp-test.
+  A more declarative approach would be to reuse ide-debug-driver:
+
+  > https://github.com/digital-asset/daml/blob/master/compiler/damlc/ide-debug-driver/README.md
+
+  The result of an experiment is a total duration in seconds after a preset
+  number of iterations. There is ample room for improvement:
+     - Statistical analysis to detect outliers and auto infer the number of iterations needed
+     - GC stats analysis (currently -S is printed as part of the experiment)
+     - Analyisis of performance over the commit history of the project
+
+
+ -}
+
+import Control.Applicative.Combinators
+import Control.Concurrent
+import Control.Monad
+import Control.Monad.IO.Class
+import Data.Aeson
+import Data.Maybe
+import Data.Version
+import Language.Haskell.LSP.Test
+import Language.Haskell.LSP.Types
+import Language.Haskell.LSP.Types.Capabilities
+import Numeric.Natural
+import System.Directory
+import System.FilePath ((</>))
+import System.Process
+import System.Time.Extra
+
+examplePackageName :: String
+examplePackageName = "Cabal"
+
+examplePackageVersion :: Version
+examplePackageVersion = makeVersion [3, 2, 0, 0]
+
+examplePackage :: String
+examplePackage = examplePackageName <> "-" <> showVersion examplePackageVersion
+
+exampleModulePath :: FilePath
+exampleModulePath = "Distribution" </> "Simple.hs"
+
+-- For some reason, the Shake profile files are truncated and won't load
+shakeProfiling :: Bool
+shakeProfiling = False
+
+main :: IO ()
+main = do
+  putStrLn "starting test"
+
+  setup
+
+  runBenchmarks
+    [ Bench "hover" 10 $ \doc ->
+        isJust <$> getHover doc (Position 853 12),
+
+      Bench "getDefinition" 10 $ \doc ->
+        not . null <$> getDefinitions doc (Position 853 12),
+
+      Bench "documentSymbols" 100 $
+        fmap (either (not . null) (not . null)) . getDocumentSymbols,
+
+      Bench "documentSymbols after edit" 100 $ \doc -> do
+        let change = TextDocumentContentChangeEvent
+                { _range = Just (Range (Position 854 23) (Position 854 23))
+                , _rangeLength = Nothing
+                , _text = " "
+                }
+        changeDoc doc [change]
+        either (not . null) (not . null) <$> getDocumentSymbols doc,
+
+      Bench "completions after edit" 10 $ \doc -> do
+        let change = TextDocumentContentChangeEvent
+                { _range = Just (Range (Position 854 23) (Position 854 23))
+                , _rangeLength = Nothing
+                , _text = " "
+                }
+        changeDoc doc [change]
+        not . null <$> getCompletions doc (Position 853 12),
+
+      Bench "code actions" 10 $ \doc -> do
+        let p = Position 853 24
+        let change = TextDocumentContentChangeEvent
+                { _range = Just (Range p p)
+                , _rangeLength = Nothing
+                , _text = "a"
+                }
+        changeDoc doc [change]
+        void (skipManyTill anyMessage message :: Session WorkDoneProgressEndNotification)
+        not . null <$> getCodeActions doc (Range p p)
+
+    ]
+
+type Experiment = TextDocumentIdentifier -> Session Bool
+
+data Bench = Bench
+  { name :: !String,
+    samples :: !Natural,
+    experiment :: !Experiment
+  }
+
+runBenchmarks :: [Bench] -> IO ()
+runBenchmarks benchmarks = do
+  results <- forM benchmarks $ \Bench {..} ->
+    (name,) <$> runBench name samples experiment
+
+  forM_ results $ \(name, duration) ->
+    putStrLn $ "TOTAL " <> name <> " = " <> showDuration duration
+
+runBench :: String -> Natural -> Experiment -> IO Seconds
+runBench name iters experiment =
+  runSessionWithConfig conf cmd lspTestCaps dir $ do
+    doc <- openDoc exampleModulePath "haskell"
+    void (skipManyTill anyMessage message :: Session WorkDoneProgressEndNotification)
+
+    liftIO $ putStrLn $ "Running " <> name <> " benchmark"
+    (t, _) <- duration2 $ replicateM_ (fromIntegral iters) $ do
+      (t, res) <- duration2 $ experiment doc
+      unless res $ fail "DIDN'T WORK"
+      liftIO $ putStrLn $ showDuration t
+
+    exitServer
+    -- sleeep to give ghcide a chance to print the RTS stats
+    liftIO $ threadDelay 50000
+
+    return t
+  where
+    cmd =
+      unwords $
+        [ "ghcide",
+          "--lsp",
+          "--test",
+          "--cwd",
+          dir,
+          "+RTS",
+          "-N4",
+          "-S",
+          "-RTS"
+        ]
+          ++ concat
+            [ ["--shake-profiling", "shake-profiling"]
+              | shakeProfiling
+            ]
+    dir = "bench/example/" <> examplePackage
+    lspTestCaps =
+      fullCaps {_window = Just $ WindowClientCapabilities $ Just True}
+    conf =
+      defaultConfig
+        { logStdErr = True,
+          logMessages = False,
+          logColor = False
+        }
+
+setup :: IO ()
+setup = do
+  alreadyExists <- doesDirectoryExist "bench/example"
+  when alreadyExists $ removeDirectoryRecursive "bench/example"
+  callCommand $ "cabal unpack " <> examplePackage <> " -d bench/example"
+  writeFile
+    ("bench/example/" <> examplePackage <> "/hie.yaml")
+    ("cradle: {cabal: {component: " <> show examplePackageName <> "}}")
+
+  when shakeProfiling
+    $ createDirectoryIfMissing True
+    $ "bench/example" </> examplePackage </> "shake-profiling"
+
+  -- print the path to ghcide (TODO platform independent)
+  callCommand "which ghcide"
+
+duration2 :: MonadIO m => m a -> m (Seconds, a)
+duration2 x = do
+  start <- liftIO offsetTime
+  res <- x
+  end <- liftIO start
+  return (end, res)
+
+-- | Asks the server to shutdown and exit politely
+exitServer :: Session ()
+exitServer = request_ Shutdown (Nothing :: Maybe Value) >> sendNotification Exit ExitParams

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -66,12 +66,16 @@ main = do
   setup
 
   runBenchmarks
-    [ bench "hover" 10 $ \doc ->
+    [ ---------------------------------------------------------------------------------------
+      bench "hover" 10 $ \doc ->
         isJust <$> getHover doc (Position 853 12),
+      ---------------------------------------------------------------------------------------
       bench "getDefinition" 10 $ \doc ->
         not . null <$> getDefinitions doc (Position 853 12),
+      ---------------------------------------------------------------------------------------
       bench "documentSymbols" 100 $
         fmap (either (not . null) (not . null)) . getDocumentSymbols,
+      ---------------------------------------------------------------------------------------
       bench "documentSymbols after edit" 100 $ \doc -> do
         let change =
               TextDocumentContentChangeEvent
@@ -81,6 +85,7 @@ main = do
                 }
         changeDoc doc [change]
         either (not . null) (not . null) <$> getDocumentSymbols doc,
+      ---------------------------------------------------------------------------------------
       bench "completions after edit" 10 $ \doc -> do
         let change =
               TextDocumentContentChangeEvent
@@ -90,6 +95,7 @@ main = do
                 }
         changeDoc doc [change]
         not . null <$> getCompletions doc (Position 853 12),
+      ---------------------------------------------------------------------------------------
       benchWithSetup
         "code actions"
         10
@@ -108,6 +114,7 @@ main = do
             void (skipManyTill anyMessage message :: Session WorkDoneProgressEndNotification)
             not . null <$> getCodeActions doc (Range p p)
         ),
+      ---------------------------------------------------------------------------------------
       bench "code actions after edit" 10 $ \doc -> do
         let p = Position 853 24
         let change =

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -108,10 +108,10 @@ main = do
                       _text = "a"
                     }
             changeDoc doc [change]
+            void (skipManyTill anyMessage message :: Session WorkDoneProgressEndNotification)
             return p
         )
         ( \p doc -> do
-            void (skipManyTill anyMessage message :: Session WorkDoneProgressEndNotification)
             not . null <$> getCodeActions doc (Range p p)
         ),
       ---------------------------------------------------------------------------------------

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -224,14 +224,14 @@ runBench Bench {..} = handleAny (\e -> print e >> return (-1))
     userState <- benchSetup doc
     let loop 0 = return True
         loop n = do
-          (t, res) <- duration2 $ experiment userState doc
+          (t, res) <- duration $ experiment userState doc
           if not res
             then return False
             else do
               output (showDuration t)
               loop (n -1)
 
-    (t, res) <- duration2 $ loop samples
+    (t, res) <- duration $ loop samples
 
     exitServer
     -- sleeep to give ghcide a chance to print the RTS stats
@@ -277,13 +277,6 @@ setup = do
 
   -- print the path to ghcide (TODO platform independent)
   when (verbose ?config) $ callCommand "which ghcide"
-
-duration2 :: MonadIO m => m a -> m (Seconds, a)
-duration2 x = do
-  start <- liftIO offsetTime
-  res <- x
-  end <- liftIO start
-  return (end, res)
 
 -- | Asks the server to shutdown and exit politely
 exitServer :: Session ()

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -246,7 +246,6 @@ runBench Bench {..} = handleAny (\e -> print e >> return (-1))
           "--cwd",
           dir,
           "+RTS",
-          "-N4",
           "-S",
           "-RTS"
         ]
@@ -268,7 +267,7 @@ setup :: HasConfig => IO ()
 setup = do
   alreadyExists <- doesDirectoryExist "bench/example"
   when alreadyExists $ removeDirectoryRecursive "bench/example"
-  callCommand $ "cabal unpack -v0 " <> examplePackage <> " -d bench/example"
+  callCommand $ "cabal get -v0 " <> examplePackage <> " -d bench/example"
   writeFile
     ("bench/example/" <> examplePackage <> "/hie.yaml")
     ("cradle: {cabal: {component: " <> show examplePackageName <> "}}")

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -278,9 +278,6 @@ setup = do
 
   whenJust (shakeProfiling ?config) $ createDirectoryIfMissing True
 
-  -- print the path to ghcide (TODO platform independent)
-  when (verbose ?config) $ callCommand "which ghcide"
-
   return $ removeDirectoryRecursive examplesPath
 
 -- | Asks the server to shutdown and exit politely

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -302,3 +302,41 @@ test-suite ghcide-tests
         TupleSections
         TypeApplications
         ViewPatterns
+
+benchmark ghcide-bench
+    type: exitcode-stdio-1.0
+    default-language: Haskell2010
+    build-tool-depends:
+        ghcide:ghcide,
+        ghcide:ghcide-test-preprocessor
+    build-depends:
+        aeson,
+        base,
+        bytestring,
+        containers,
+        directory,
+        extra,
+        filepath,
+        ghcide,
+        lsp-test >= 0.11.0.1 && < 0.12,
+        parser-combinators,
+        process
+    hs-source-dirs: bench
+    include-dirs: include
+    ghc-options: -threaded -Wall -Wno-name-shadowing
+    main-is: Main.hs
+    other-modules:
+    default-extensions:
+        BangPatterns
+        DeriveFunctor
+        DeriveGeneric
+        GeneralizedNewtypeDeriving
+        LambdaCase
+        NamedFieldPuns
+        OverloadedStrings
+        RecordWildCards
+        ScopedTypeVariables
+        StandaloneDeriving
+        TupleSections
+        TypeApplications
+        ViewPatterns

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -318,9 +318,11 @@ benchmark ghcide-bench
         extra,
         filepath,
         ghcide,
-        lsp-test >= 0.11.0.1 && < 0.12,
+        lsp-test < 0.12,
+        optparse-applicative,
         parser-combinators,
-        process
+        process,
+        safe-exceptions
     hs-source-dirs: bench
     include-dirs: include
     ghc-options: -threaded -Wall -Wno-name-shadowing

--- a/hie.yaml
+++ b/hie.yaml
@@ -6,5 +6,7 @@ cradle:
       component: "ghcide:exe:ghcide"
     - path: "./test"
       component: "ghcide:test:ghcide-tests"
+    - path: "./bench"
+      component: "ghcide:benchmark:ghcide-bench"
     - path: "./test/preprocessor"
       component: "ghcide:exe:ghcide-test-preprocessor"


### PR DESCRIPTION
The benchmark suite is designed to be run with `cabal bench`. It does not attempt to compare with past performance, I think that's better tackled as a separate task.

The module comment in the benchmark module contains some details on the benchmark methodology and experiments, which currently cover the basics:

- hover
- go to definition
- completions
- code actions
- document symbols

I have not made any attempts to integrate with CI since I don't know how consistent the timings would be across runs. 

Goes some way towards closing #242 