### PR TITLE
Add back a .ghci file

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,0 +1,25 @@
+:set -Wunused-binds -Wunused-imports -Worphans -Wunused-matches -Wincomplete-patterns
+
+:set -XBangPatterns
+:set -XDeriveFunctor
+:set -XDeriveGeneric
+:set -XGeneralizedNewtypeDeriving
+:set -XLambdaCase
+:set -XNamedFieldPuns
+:set -XOverloadedStrings
+:set -XRecordWildCards
+:set -XScopedTypeVariables
+:set -XStandaloneDeriving
+:set -XTupleSections
+:set -XTypeApplications
+:set -XViewPatterns
+
+:set -package=ghc
+:set -ignore-package=ghc-lib-parser
+:set -DGHC_STABLE
+:set -Iinclude
+:set -idist/build/autogen
+:set -isrc
+:set -iexe
+
+:load Main


### PR DESCRIPTION
Allegedly it's possible to develop Ghcide without using Ghcid. I am yet to be convinced, and certainly I can't do it.