### PR TITLE
Use a better noRange

### DIFF
--- a/src/Development/IDE/Types/Location.hs
+++ b/src/Development/IDE/Types/Location.hs
@@ -69,7 +69,7 @@ noFilePath = "<unknown>"
 
 -- A dummy range to use when range is unknown
 noRange :: Range
-noRange =  Range (Position 0 0) (Position 100000 0)
+noRange =  Range (Position 0 0) (Position 1 0)
 
 showPosition :: Position -> String
 showPosition Position{..} = show (_line + 1) ++ ":" ++ show (_character + 1)


### PR DESCRIPTION
When there is a catastrophic failure to load a cradle (e.g. #610) the consequence is that every file is highlighted in red everywhere. If you want to continue developing with something like Ghcid it's super annoying to have to try and see the code under this sea of red. Solution is to treat cradle errors as being diagnostics spanning the first line of every file. It's still clear the error is there, you can still look at it, but it's not all you have to look at. There's no good reason to highlight an entire file in red.