### PR TITLE
Allow stale data back in GetSpanInfo rule

### DIFF
--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -451,10 +451,10 @@ getSpanInfoRule =
 #if MIN_GHC_API_VERSION(8,6,0) && !defined(GHC_LIB)
         let parsedDeps = []
 #else
-        parsedDeps <- uses_ GetParsedModule tdeps
+        parsedDeps <- mapMaybe (fmap fst) <$> usesWithStale GetParsedModule tdeps
 #endif
 
-        ifaces <- uses_ GetModIface tdeps
+        ifaces <- mapMaybe (fmap fst) <$> usesWithStale GetModIface tdeps
         (fileImports, _) <- use_ GetLocatedImports file
         let imports = second (fmap artifactFilePath) <$> fileImports
         x <- liftIO $ getSrcSpanInfos packageState imports tc parsedDeps (map hirModIface ifaces)


### PR DESCRIPTION
GetSpanInfo allowed stale dependencies prior to #457 and was changed to disallow them for no good reason, which makes hovers unavailable when a dependency doesn't typecheck

While I was there, I also dropped early cutoff from GetHiFile as it seems unnecessary. 

No impact in performance:

### Before
```
name                       | samples | startup | setup | experiment | maxResidency
-------------------------- | ------- | ------- | ----- | ---------- | ------------
hover                      | 10      | 7.50s   | 0.00s | 9.71s      | 168MB       
hover after edit           | 10      | 7.25s   | 0.00s | 13.61s     | 151MB       
getDefinition              | 10      | 7.24s   | 0.00s | 5.92s      | 145MB       
documentSymbols            | 100     | 7.25s   | 0.00s | 1.43s      | 28MB        
documentSymbols after edit | 100     | 7.25s   | 0.00s | 2.77s      | 29MB        
completions after edit     | 10      | 7.26s   | 0.00s | 9.79s      | 153MB       
code actions               | 10      | 7.28s   | 5.06s | 0.39s      | 47MB        
code actions after edit    | 10      | 7.38s   | 0.00s | 9.11s      | 173MB       
```
### After
```
name                       | samples | startup | setup | experiment | maxResidency
-------------------------- | ------- | ------- | ----- | ---------- | ------------
hover                      | 10      | 7.51s   | 0.00s | 9.85s      | 168MB       
hover after edit           | 10      | 7.28s   | 0.00s | 13.58s     | 152MB       
getDefinition              | 10      | 7.32s   | 0.00s | 5.99s      | 145MB       
documentSymbols            | 100     | 7.33s   | 0.00s | 1.42s      | 28MB        
documentSymbols after edit | 100     | 7.40s   | 0.00s | 2.79s      | 30MB        
completions after edit     | 10      | 7.31s   | 0.00s | 9.85s      | 152MB       
code actions               | 10      | 7.30s   | 5.12s | 0.39s      | 47MB        
code actions after edit    | 10      | 7.20s   | 0.00s | 9.19s      | 173MB   
```