### PR TITLE
Fix a bug in getHiFileRule

### DIFF
--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -97,9 +97,9 @@ type instance RuleResult GetLocatedImports = ([(Located ModuleName, Maybe Artifa
 -- we can only report diagnostics for the current file.
 type instance RuleResult ReportImportCycles = ()
 
--- | Read the module interface file directly. Throws an error for VFS files.
+-- | Read the module interface file from disk. Throws an error for VFS files.
 --   This is an internal rule, use 'GetModIface' instead.
-type instance RuleResult GetHiFile = HiFileResult
+type instance RuleResult GetModIfaceFromDisk = HiFileResult
 
 -- | Get a module interface details, either from an interface file or a typechecked module
 type instance RuleResult GetModIface = HiFileResult
@@ -170,11 +170,11 @@ instance Hashable GhcSession
 instance NFData   GhcSession
 instance Binary   GhcSession
 
-data GetHiFile = GetHiFile
+data GetModIfaceFromDisk = GetModIfaceFromDisk
     deriving (Eq, Show, Typeable, Generic)
-instance Hashable GetHiFile
-instance NFData   GetHiFile
-instance Binary   GetHiFile
+instance Hashable GetModIfaceFromDisk
+instance NFData   GetModIfaceFromDisk
+instance Binary   GetModIfaceFromDisk
 
 data GetModIface = GetModIface
     deriving (Eq, Show, Typeable, Generic)

--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -97,10 +97,11 @@ type instance RuleResult GetLocatedImports = ([(Located ModuleName, Maybe Artifa
 -- we can only report diagnostics for the current file.
 type instance RuleResult ReportImportCycles = ()
 
--- | Read the module interface file
+-- | Read the module interface file directly. Throws an error for VFS files.
+--   This is an internal rule, use 'GetModIface' instead.
 type instance RuleResult GetHiFile = HiFileResult
 
--- | Get a module interface, either from an interface file or a typechecked module
+-- | Get a module interface details, either from an interface file or a typechecked module
 type instance RuleResult GetModIface = HiFileResult
 
 type instance RuleResult IsFileOfInterest = Bool

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -588,8 +588,8 @@ loadGhcSession = do
                 Nothing -> BS.pack (show (hash (snd val)))
         return (Just cutoffHash, val)
 
-getHiFileRule :: Rules ()
-getHiFileRule = defineEarlyCutoff $ \GetHiFile f -> do
+getModIfaceFromDiskRule :: Rules ()
+getModIfaceFromDiskRule = defineEarlyCutoff $ \GetModIfaceFromDisk f -> do
   -- get all dependencies interface files, to check for freshness
   (deps,_) <- use_ GetLocatedImports f
   depHis  <- traverse (use GetModIface) (mapMaybe (fmap artifactFilePath . snd) deps)
@@ -618,7 +618,7 @@ getHiFileRule = defineEarlyCutoff $ \GetHiFile f -> do
                     let diag = ideErrorWithSource (Just "interface file loading") (Just DsError) f . T.pack $ err
                     return (Nothing, (pure diag, Nothing))
             (_, VFSVersion{}) ->
-                error "internal error - GetHiFile of file of interest"
+                error "internal error - GetModIfaceFromDisk of file of interest"
             _ ->
               pure (Nothing, ([], Nothing))
 
@@ -636,7 +636,7 @@ getModIfaceRule = define $ \GetModIface f -> do
     let useHiFile =
           -- Never load interface files for files of interest
           not fileOfInterest
-    mbHiFile <- if useHiFile then use GetHiFile f else return Nothing
+    mbHiFile <- if useHiFile then use GetModIfaceFromDisk f else return Nothing
     case mbHiFile of
         Just x ->
             return ([], Just x)
@@ -696,7 +696,7 @@ mainRule = do
     generateCoreRule
     generateByteCodeRule
     loadGhcSession
-    getHiFileRule
+    getModIfaceFromDiskRule
     getModIfaceRule
     isFileOfInterestRule
     getModSummaryRule

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -592,7 +592,7 @@ getHiFileRule :: Rules ()
 getHiFileRule = defineEarlyCutoff $ \GetHiFile f -> do
   -- get all dependencies interface files, to check for freshness
   (deps,_) <- use_ GetLocatedImports f
-  depHis  <- traverse (use GetHiFile) (mapMaybe (fmap artifactFilePath . snd) deps)
+  depHis  <- traverse (use GetModIface) (mapMaybe (fmap artifactFilePath . snd) deps)
 
   ms <- use_ GetModSummary f
   let hiFile = toNormalizedFilePath'


### PR DESCRIPTION
After merging #589 ghcide now errors out occassionally with `internal error - GetHiFile of file of interest`. 

This is great! It uncovers a real bug in `getHiFileRule`, although I'm not sure if the bug would have any user impact.

The problem is that `getHiFileRule` has direct dependencies on `GetHiFile`, which is wrong for the reasons explained in the expanded comment.
