### PR TITLE
Add hie.yaml.stack and use none cradle for test data

### DIFF
--- a/hie.yaml.cbl
+++ b/hie.yaml.cbl
@@ -12,7 +12,5 @@ cradle:
               component: "ghcide:exe:ghcide"
             - path: "./test"
               component: "ghcide:test:ghcide-tests"
-            - path: "./bench"
-              component: "ghcide:bench:ghcide-bench"
             - path: "./test/preprocessor"
               component: "ghcide:exe:ghcide-test-preprocessor"

--- a/hie.yaml.stack
+++ b/hie.yaml.stack
@@ -1,0 +1,18 @@
+cradle:
+  multi:
+    - path: "./test/data"
+      config: { cradle: { none:  } }
+    - path: "./"
+      config:
+        cradle:
+          stack:
+            - path: "./src"
+              component: "ghcide:lib"
+            - path: "./exe"
+              component: "ghcide:exe:ghcide"
+            - path: "./test"
+              component: "ghcide:test:ghcide-tests"
+            - path: "./bench"
+              component: "ghcide:bench:ghcide-bench"
+            - path: "./test/preprocessor"
+              component: "ghcide:exe:ghcide-test-preprocessor"


### PR DESCRIPTION
* I think ghcide is already supporting the none cradle so we will leverage it here
* The stack based hie.yaml could be handy for stack users (not sure if it should be the default one)