### PR TITLE
Put LspFuncs in ShakeExtras, report progress for cradle setup

### DIFF
--- a/src/Development/IDE/Core/Service.hs
+++ b/src/Development/IDE/Core/Service.hs
@@ -26,9 +26,8 @@ import           Development.IDE.Core.FileExists (fileExistsRules)
 import           Development.IDE.Core.OfInterest
 import Development.IDE.Types.Logger
 import           Development.Shake
-import qualified Language.Haskell.LSP.Messages as LSP
+import qualified Language.Haskell.LSP.Core as LSP
 import qualified Language.Haskell.LSP.Types as LSP
-import qualified Language.Haskell.LSP.Types.Capabilities as LSP
 
 import           Development.IDE.Core.Shake
 
@@ -41,19 +40,16 @@ instance IsIdeGlobal GlobalIdeOptions
 -- Exposed API
 
 -- | Initialise the Compiler Service.
-initialise :: LSP.ClientCapabilities
+initialise :: LSP.LspFuncs config
            -> Rules ()
-           -> IO LSP.LspId
-           -> (LSP.FromServerMessage -> IO ())
            -> Logger
            -> Debouncer LSP.NormalizedUri
            -> IdeOptions
            -> VFSHandle
            -> IO IdeState
-initialise caps mainRule getLspId toDiags logger debouncer options vfs =
+initialise lspFuncs mainRule logger debouncer options vfs =
     shakeOpen
-        getLspId
-        toDiags
+        lspFuncs
         logger
         debouncer
         (optShakeProfiling options)
@@ -66,7 +62,7 @@ initialise caps mainRule getLspId toDiags logger debouncer options vfs =
             addIdeGlobal $ GlobalIdeOptions options
             fileStoreRules vfs
             ofInterestRules
-            fileExistsRules getLspId caps vfs
+            fileExistsRules lspFuncs vfs
             mainRule
 
 writeProfile :: IdeState -> FilePath -> IO ()


### PR DESCRIPTION
This sends a progress message when consulting a cradle, and to do so passes about the `LspFuncs` in `ShakeExtras`. This replaces the need for the `eventer`/`sendFunc` and `getLspId`, since they can just be obtained via `LspFuncs`.

In future versions of `haskell-lsp`, the request id stuff will be hidden away inside `LspFuncs` so this will also help future proof it