### PR TITLE
Performance analysis over time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,7 @@ cabal.project.local
 /.tasty-rerun-log
 .vscode
 /.hlint-*
-bench/example
+bench/example/
+bench-hist/
+bench-temp/
+.shake/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ bench/example/
 bench-hist/
 bench-temp/
 .shake/
+ghcide
+*.benchmark-gcStats

--- a/bench/Hist/Main.hs
+++ b/bench/Hist/Main.hs
@@ -71,9 +71,6 @@ readConfigIO = do
 readConfig :: Action Config
 readConfig = need [config] >> liftIO readConfigIO
 
-build :: String
-build = "bench-hist"
-
 newtype GetSamples = GetSamples () deriving newtype (Binary, Eq, Hashable, NFData, Show)
 
 newtype GetExperiments = GetExperiments () deriving newtype (Binary, Eq, Hashable, NFData, Show)
@@ -107,6 +104,8 @@ main = shakeArgs shakeOptions {shakeChange = ChangeModtimeAndDigest} $ do
       readExperiments = askOracle $ GetExperiments ()
       readSamples = askOracle $ GetSamples ()
       getParent = askOracle . GetParent
+
+  build <- liftIO $ outputFolder <$> readConfigIO
 
   phony "all" $ do
     Config {..} <- readConfig
@@ -269,7 +268,9 @@ data Config = Config
     samples :: Natural,
     versions :: [GitCommit],
     -- | Path to the ghcide-bench binary for the experiments
-    ghcideBench :: FilePath
+    ghcideBench :: FilePath,
+    -- | Output folder ('foo' works, 'foo/bar' does not)
+    outputFolder :: String
   }
   deriving (Generic, Show)
   deriving anyclass (FromJSON, ToJSON)

--- a/bench/Hist/Main.hs
+++ b/bench/Hist/Main.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingStrategies #-}
 {-  Bench history
 
     A Shake script to analyze the performance of ghcide over the git history of the project
@@ -39,13 +36,9 @@
    > stack exec benchHist bench-hist/HEAD/results.csv bench-hist/HEAD/edit.diff.svg
 
  -}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DerivingStrategies#-}
+{-# LANGUAGE TypeFamilies      #-}
 
 import Control.Applicative (Alternative (empty))
 import Control.Monad (forM, forM_, replicateM)
@@ -137,7 +130,7 @@ main = shakeArgs shakeOptions {shakeChange = ChangeModtimeAndDigest} $ do
       let [_,ver,_] = splitDirectories out
       mbEntry <- find ((== T.pack ver) . humanName) <$> readVersions
       let gitThing :: String
-          gitThing = fromMaybe ver $ T.unpack . gitName <$> mbEntry
+          gitThing = maybe ver (T.unpack . gitName) mbEntry
       Stdout commitid <- command [] "git" ["rev-list", "-n", "1", gitThing]
       writeFileChanged out $ init commitid
 
@@ -382,7 +375,7 @@ data RunLog = RunLog
 
 loadRunLog :: FilePath -> Escaped FilePath -> FilePath -> Action RunLog
 loadRunLog buildF exp ver = do
-  let fp = (buildF </> ver </> escaped exp <.> "benchmark-gcStats")
+  let fp = buildF </> ver </> escaped exp <.> "benchmark-gcStats"
   need [fp]
   log <- liftIO $ lines <$> readFile fp
   let frames =

--- a/bench/Hist/Main.hs
+++ b/bench/Hist/Main.hs
@@ -397,16 +397,16 @@ plotDiagram includeFailed t@Diagram {traceMetric, runLogs} out = do
   let extract = frameMetric traceMetric
   liftIO $ E.toFile E.def out $ do
     E.layout_title .= title t
+    E.setColors myColors
     forM_ runLogs $ \rl ->
-      when (includeFailed || runSuccess rl) $
-        E.plot
-          ( E.line
-              (runVersion rl ++ if runSuccess rl then "" else " (FAILED)")
-              [ [ (totElapsed f, extract f)
-                  | f <- runFrames rl
+      when (includeFailed || runSuccess rl) $ E.plot $ do
+        lplot <- E.line
+            (runVersion rl ++ if runSuccess rl then "" else " (FAILED)")
+            [ [ (totElapsed f, extract f)
+                | f <- runFrames rl
                 ]
-              ]
-          )
+            ]
+        return (lplot E.& E.plot_lines_style . E.line_width E.*~ 2)
 
 s :: String -> String
 s = id
@@ -430,3 +430,44 @@ unescapeExperiment = Unescaped . map f . escaped
   where
     f '_' = ' '
     f other = other
+
+myColors :: [E.AlphaColour Double]
+myColors = map E.opaque
+  [ E.blue
+  , E.green
+  , E.red
+  , E.orange
+  , E.yellow
+  , E.violet
+  , E.black
+  , E.gold
+  , E.brown
+  , E.hotpink
+  , E.aliceblue
+  , E.aqua
+  , E.beige
+  , E.bisque
+  , E.blueviolet
+  , E.burlywood
+  , E.cadetblue
+  , E.chartreuse
+  , E.coral
+  , E.crimson
+  , E.darkblue
+  , E.darkgray
+  , E.darkgreen
+  , E.darkkhaki
+  , E.darkmagenta
+  , E.deeppink
+  , E.dodgerblue
+  , E.firebrick
+  , E.forestgreen
+  , E.fuchsia
+  , E.greenyellow
+  , E.lightsalmon
+  , E.seagreen
+  , E.olive
+  , E.sandybrown
+  , E.sienna
+  , E.peru
+  ]

--- a/bench/Hist/Main.hs
+++ b/bench/Hist/Main.hs
@@ -46,7 +46,7 @@ import Data.Foldable (find)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.Yaml ((.!=), (.:), (.:?), FromJSON (..), ToJSON (..), Value (..), decodeFileThrow)
+import Data.Yaml ((.!=), (.:?), FromJSON (..), ToJSON (..), Value (..), decodeFileThrow)
 import Development.Shake
 import Development.Shake.Classes (Binary, Hashable, NFData)
 import GHC.Exts (IsList (..))
@@ -291,7 +291,7 @@ instance FromJSON GitCommit where
     pure $ GitCommit gitName (Just name) Nothing True
   parseJSON (Object (toList -> [(name, Object props)])) =
     GitCommit
-      <$> props .: "git"
+      <$> props .:? "git"  .!= name
       <*> pure (Just name)
       <*> props .:? "parent"
       <*> props .:? "include" .!= True

--- a/bench/Hist/Main.hs
+++ b/bench/Hist/Main.hs
@@ -1,0 +1,416 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-  Bench history
+
+    A Shake script to analyze the performance of ghcide over the git history of the project
+
+    Driven by a config file `bench/hist.yaml` containing the list of Git references to analyze.
+
+    Builds each one of them and executes a set of experiments using the ghcide-bench suite.
+
+    The results of the benchmarks and the analysis are recorded in the file
+    system with the following structure:
+
+    bench-hist
+    ├── <git-reference>                       - one folder per version
+    │   ├── <experiment>.benchmark-gcStats    - RTS -s output
+    │   ├── <experiment>.csv                  - stats for the experiment
+    │   ├── <experiment>.svg                  - Graph of bytes over elapsed time
+    │   ├── <experiment>.diff.svg             - idem, including the previous version
+    │   ├── <experiment>.log                  - ghcide-bench output
+    │   ├── ghc.path                          - path to ghc used to build the binary
+    │   ├── ghcide                            - binary for this version
+    │   └── results.csv                       - results of all the experiments for the version
+    ├── results.csv        - aggregated results of all the experiments and versions
+    ├── <experiment>.svg   - graph of bytes over elapsed time, for all the included versions
+
+   For diff graphs, the "previous version" is the preceding entry in the list of versions
+   in the config file. A possible improvement is to obtain this info via `git rev-list`.
+
+   The script relies on stack for building and running all the binaries.
+
+   To execute the script:
+
+   > stack build ghcide:exe:benchHist && stack exec benchHist all
+
+   To build a specific analysis, enumerate the desired file artifacts
+
+   > stack exec benchHist bench-hist/HEAD/results.csv bench-hist/HEAD/edit.diff.svg
+
+ -}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ViewPatterns #-}
+
+import Control.Applicative (Alternative (empty))
+import Control.Monad (forM, forM_, replicateM)
+import Data.Foldable (find)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.Yaml ((.!=), (.:), (.:?), FromJSON (..), ToJSON (..), Value (..), decodeFileThrow)
+import Development.Shake
+import Development.Shake.Classes (Binary, Hashable, NFData)
+import GHC.Exts (IsList (..))
+import GHC.Generics (Generic)
+import qualified Graphics.Rendering.Chart.Backend.Diagrams as E
+import Graphics.Rendering.Chart.Easy ((.=))
+import qualified Graphics.Rendering.Chart.Easy as E
+import Numeric.Natural (Natural)
+import System.Directory
+import System.FilePath
+import qualified Text.ParserCombinators.ReadP as P
+import Text.Read (Read (..), get, readMaybe, readP_to_Prec)
+
+config :: FilePath
+config = "bench/hist.yaml"
+
+-- | Read the config without dependency
+readConfigIO :: IO Config
+readConfigIO = do
+  decodeFileThrow config
+
+readConfig :: Action Config
+readConfig = need [config] >> liftIO readConfigIO
+
+build :: String
+build = "bench-hist"
+
+newtype GetSamples = GetSamples () deriving newtype (Binary, Eq, Hashable, NFData, Show)
+
+newtype GetExperiments = GetExperiments () deriving newtype (Binary, Eq, Hashable, NFData, Show)
+
+newtype GetVersions = GetVersions () deriving newtype (Binary, Eq, Hashable, NFData, Show)
+
+newtype GetParent = GetParent Text deriving newtype (Binary, Eq, Hashable, NFData, Show)
+
+newtype GetCommitId = GetCommitId String deriving newtype (Binary, Eq, Hashable, NFData, Show)
+
+type instance RuleResult GetSamples = Natural
+
+type instance RuleResult GetExperiments = [Unescaped String]
+
+type instance RuleResult GetVersions = [GitCommit]
+
+type instance RuleResult GetParent = Text
+
+type instance RuleResult GetCommitId = String
+
+main :: IO ()
+main = shakeArgs shakeOptions {shakeChange = ChangeModtimeAndDigest} $ do
+  want ["all"]
+
+  _ <- addOracle $ \GetSamples {} -> samples <$> readConfig
+  _ <- addOracle $ \GetExperiments {} -> experiments <$> readConfig
+  _ <- addOracle $ \GetVersions {} -> versions <$> readConfig
+  _ <- addOracle $ \(GetParent name) -> findPrev name . versions <$> readConfig
+  _ <- addOracle $ \(GetCommitId human) -> (`nameToGit` human) . versions <$> readConfig
+
+  let readVersions = askOracle $ GetVersions ()
+      readExperiments = askOracle $ GetExperiments ()
+      readSamples = askOracle $ GetSamples ()
+      getParent = askOracle . GetParent
+      getCommitId = askOracle . GetCommitId
+
+  phony "all" $ do
+    Config {..} <- readConfig
+
+    forM_ versions $ \ver ->
+      need [build </> T.unpack (humanName ver) </> "results.csv"]
+
+    need $
+      [build </> "results.csv"]
+        ++ [ build </> escaped(escapeExperiment e) <.> "svg"
+             | e <- experiments
+           ]
+        ++ [ build </> T.unpack (humanName ver) </> escaped(escapeExperiment e) <.> mode <.> "svg"
+             | e <- experiments,
+               ver <- versions,
+               mode <- ["", "diff"]
+           ]
+
+  [  build -/- "*/ghcide"
+   , build -/- "*/ghc.path"
+   ] &%> \[out, ghcpath] -> do
+    let [_, ver, _] = splitDirectories out
+    liftIO $ createDirectoryIfMissing True $ dropFileName out
+    commitid <- getCommitId ver
+    cmd_ $ "git worktree add bench-temp " ++ commitid
+    Stdout ghcLoc <-
+      cmd
+        [Cwd "bench-temp"]
+        (s "stack --stack-yaml=stack88.yaml exec which ghc")
+    cmd_
+      [Cwd "bench-temp"]
+      ( "stack --local-bin-path=../" <> takeDirectory out
+          <> " --stack-yaml=stack88.yaml build ghcide:ghcide --copy-bins --ghc-options -rtsopts"
+      )
+      `actionFinally` cmd_ (s "git worktree remove bench-temp --force")
+    writeFile' ghcpath ghcLoc
+
+  priority 8000 $
+    build -/- "*/results.csv" %> \out -> do
+      experiments <- readExperiments
+
+      let allResultFiles = [takeDirectory out </> escaped(escapeExperiment e) <.> "csv" | e <- experiments]
+      allResults <- traverse readFileLines allResultFiles
+
+      let header = head $ head allResults
+          results = map tail allResults
+      writeFileChanged out $ unlines $ header : concat results
+
+  ghcideBenchResource <- newResource "ghcide-bench" 1
+
+  priority 0 $
+    [ build -/- "*/*.csv"
+    , build -/- "*/*.benchmark-gcStats"
+    ] &%> \[outcsv, _outGc] -> do
+      let [_, _, exp] = splitDirectories outcsv
+      samples <- readSamples
+      liftIO $ createDirectoryIfMissing True $ dropFileName outcsv
+      let ghcide = dropFileName outcsv </> "ghcide"
+          ghcpath = dropFileName outcsv </> "ghc.path"
+      need [ghcide, ghcpath]
+      ghcPath <- readFile' ghcpath
+      ghcideBenchPath <- ghcideBench <$> liftIO readConfigIO
+      verb <- getVerbosity
+      withResource ghcideBenchResource 1 $ do
+        Stdout res <-
+            command
+            [ EchoStdout True,
+                RemEnv "NIX_GHC_LIBDIR",
+                RemEnv "GHC_PACKAGE_PATH",
+                AddPath [takeDirectory ghcPath, "."] []
+            ]
+            ghcideBenchPath
+                ["--timeout=3000",
+                "--samples=" <> show samples,
+                "--csv=" <> outcsv,
+                "--example-package-version=3.0.0.0",
+                "--rts=-I0.5",
+                "--ghcide=" <> ghcide,
+                "--select",
+                unescaped(unescapeExperiment(Escaped $ dropExtension exp)),
+                if verb > Normal then "-v" else "-q"
+                ]
+        writeFile' (replaceExtension outcsv "log") res
+        cmd_ Shell $ "mv *.benchmark-gcStats " <> dropFileName outcsv
+
+  build -/- "results.csv" %> \out -> do
+    versions <- readVersions
+    let allResultFiles =
+          [build </> T.unpack (humanName v) </> "results.csv" | v <- versions]
+
+    need [build </> T.unpack (humanName v) </> "ghcide" | v <- versions]
+
+    allResults <- traverse readFileLines allResultFiles
+
+    let header = head $ head allResults
+        results = map tail allResults
+        header' = "version, " <> header
+        results' = zipWith (\v -> map (\l -> T.unpack (humanName v) <> ", " <> l)) versions results
+
+    writeFileChanged out $ unlines $ header' : concat results'
+
+  priority 2 $
+    build -/- "*/*.diff.svg" %> \out -> do
+      let [b, ver, exp_] = splitDirectories out
+          exp = Escaped $ dropExtension $ dropExtension exp_
+      prev <- getParent $ T.pack ver
+
+      runLog <- loadRunLog b exp ver
+      runLogPrev <- loadRunLog b exp $ T.unpack prev
+
+      let diagram = Diagram Live [runLog, runLogPrev] title
+          title = show(unescapeExperiment exp) <> " - live bytes over time compared"
+      plotDiagram diagram out
+
+  priority 1 $
+    build -/- "*/*.svg" %> \out -> do
+      let [b, ver, exp] = splitDirectories out
+      runLog <- loadRunLog b (Escaped $ dropExtension exp) ver
+      let diagram = Diagram Live [runLog] title
+          title = ver <> " live bytes over time"
+      plotDiagram diagram out
+
+  build -/- "*.svg" %> \out -> do
+    let exp = Escaped $ dropExtension $ takeFileName out
+    versions <- readVersions
+
+    runLogs <- forM (filter include versions) $ \v -> do
+      loadRunLog build exp $ T.unpack $ humanName v
+
+    let diagram = Diagram Live runLogs title
+        title = show(unescapeExperiment exp) <> " - live bytes over time"
+    plotDiagram diagram out
+
+----------------------------------------------------------------------------------------------------
+
+data Config = Config
+  { experiments :: [Unescaped String],
+    samples :: Natural,
+    versions :: [GitCommit],
+    -- | Path to the ghcide-bench binary for the experiments
+    ghcideBench :: FilePath
+  }
+  deriving (Generic, Show)
+  deriving anyclass (FromJSON, ToJSON)
+
+data GitCommit = GitCommit
+  { -- | A git hash, tag or branch name (e.g. v0.1.0)
+    gitName :: Text,
+    -- | A human understandable name (e.g. fix-collisions-leak)
+    name :: Maybe Text,
+    -- | The human understandable name of the parent, if specified explicitly
+    parent :: Maybe Text,
+    -- | Whether to include this version in the top chart
+    include :: Bool
+  }
+  deriving (Binary, Eq, Hashable, Generic, NFData, Show)
+
+instance FromJSON GitCommit where
+  parseJSON (String s) = pure $ GitCommit s Nothing Nothing True
+  parseJSON (Object (toList -> [(name, String gitName)])) =
+    pure $ GitCommit gitName (Just name) Nothing True
+  parseJSON (Object (toList -> [(name, Object props)])) =
+    GitCommit
+      <$> props .: "git"
+      <*> pure (Just name)
+      <*> props .:? "parent"
+      <*> props .:? "include" .!= True
+  parseJSON _ = empty
+
+instance ToJSON GitCommit where
+  toJSON GitCommit {..} =
+    case name of
+      Nothing -> String gitName
+      Just n -> Object $ fromList [(n, String gitName)]
+
+humanName :: GitCommit -> Text
+humanName GitCommit {..} = fromMaybe gitName name
+
+nameToGit :: [GitCommit] -> String -> String
+nameToGit versions n =
+  maybe n (T.unpack . gitName) $ find ((== T.pack n) . humanName) versions
+
+findPrev :: Text -> [GitCommit] -> Text
+findPrev name (x : y : xx)
+  | humanName y == name = humanName x
+  | otherwise = findPrev name (y : xx)
+findPrev name _ = name
+
+----------------------------------------------------------------------------------------------------
+
+-- | A line in the output of -S
+data Frame = Frame
+  { allocated, copied, live :: !Int,
+    user, elapsed, totUser, totElapsed :: !Double,
+    generation :: !Int
+  }
+  deriving (Show)
+
+instance Read Frame where
+  readPrec = do
+    spaces
+    allocated <- readPrec @Int <* spaces
+    copied <- readPrec @Int <* spaces
+    live <- readPrec @Int <* spaces
+    user <- readPrec @Double <* spaces
+    elapsed <- readPrec @Double <* spaces
+    totUser <- readPrec @Double <* spaces
+    totElapsed <- readPrec @Double <* spaces
+    _ <- readPrec @Int <* spaces
+    _ <- readPrec @Int <* spaces
+    "(Gen:  " <- replicateM 7 get
+    generation <- readPrec @Int
+    ')' <- get
+    return Frame {..}
+    where
+      spaces = readP_to_Prec $ const P.skipSpaces
+
+data TraceMetric = Allocated | Copied | Live | User | Elapsed
+  deriving (Generic, Enum, Bounded, Read)
+
+instance Show TraceMetric where
+  show Allocated = "Allocated bytes"
+  show Copied = "Copied bytes"
+  show Live = "Live bytes"
+  show User = "User time"
+  show Elapsed = "Elapsed time"
+
+frameMetric :: TraceMetric -> Frame -> Double
+frameMetric Allocated = fromIntegral . allocated
+frameMetric Copied = fromIntegral . copied
+frameMetric Live = fromIntegral . live
+frameMetric Elapsed = elapsed
+frameMetric User = user
+
+data Diagram = Diagram
+  { traceMetric :: TraceMetric,
+    runLogs :: [RunLog],
+    title :: String
+  }
+  deriving (Generic)
+
+-- | A file path containing the output of -S for a given run
+data RunLog = RunLog
+  { runVersion :: !String,
+    _runExperiment :: !String,
+    runFrames :: ![Frame]
+  }
+
+loadRunLog :: FilePath -> Escaped FilePath -> FilePath -> Action RunLog
+loadRunLog buildF exp ver = do
+  let fp = (buildF </> ver </> escaped exp <.> "benchmark-gcStats")
+  need [fp]
+  log <- liftIO $ lines <$> readFile fp
+  let frames =
+        [ f
+          | l <- log,
+            Just f <- [readMaybe l],
+            -- filter out gen 0 events as there are too many
+            generation f == 1
+        ]
+  return $ RunLog ver (dropExtension $ escaped exp) frames
+
+plotDiagram :: Diagram -> FilePath -> Action ()
+plotDiagram t@Diagram {traceMetric, runLogs} out = do
+  let extract = frameMetric traceMetric
+  liftIO $ E.toFile E.def out $ do
+    E.layout_title .= title t
+    forM_ runLogs $ \rl ->
+      E.plot
+        ( E.line
+            (runVersion rl)
+            [ [ (totElapsed f, extract f)
+                | f <- runFrames rl
+              ]
+            ]
+        )
+
+s :: String -> String
+s = id
+
+(-/-) :: FilePattern -> FilePattern -> FilePattern
+a -/- b = a <> "/" <> b
+
+newtype Escaped a = Escaped { escaped :: a}
+newtype Unescaped a = Unescaped { unescaped :: a}
+  deriving newtype (Show, FromJSON, ToJSON, Eq, NFData, Binary, Hashable)
+
+escapeExperiment :: Unescaped String -> Escaped String
+escapeExperiment = Escaped . map f . unescaped
+  where
+    f ' ' = '_'
+    f other = other
+
+unescapeExperiment :: Escaped String -> Unescaped String
+unescapeExperiment = Unescaped . map f . escaped
+  where
+    f '_' = ' '
+    f other = other

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,14 @@
+
+# Benchmarks
+
+This folder contains two Haskell programs that work together to simplify the
+performance analysis of ghcide:
+
+- `Main.hs` - a standalone benchmark suite. Run with `stack bench`
+- `hist/Main.hs` - a Shake script for running the benchmark suite over a set of commits.
+  - Run with `stack exec benchHist`,
+  - Requires a `ghcide-bench` binary in the PATH,
+  - Calls `stack` internally to build the project,
+  - Driven by the `hist.yaml` configuration file. By default it compares HEAD with upstream
+
+Further details available in the module header comments.

--- a/bench/hist.yaml
+++ b/bench/hist.yaml
@@ -3,7 +3,7 @@
 samples: 100
 
 # Path to the ghcide-bench binary to use for experiments
-ghcideBench: ./ghcide-bench
+ghcideBench: ghcide-bench
 
 # The set of experiments to execute
 experiments:
@@ -18,40 +18,22 @@ experiments:
 
 # An ordered list of versions to analyze
 versions:
+# A version can be defined briefly:
+# - <tag>
+# - <branch>
+# - <commit hash>
+
+# Or in extended form:
+# - <name>:
+#    - git: <tag/branch/commithash>
+#    - include: true                   # whether to include in comparison graphs
+#    - parent: <tag/branch/commithash> # version to compare with in .diff graphs
+
+
 # - v0.0.5
 # - v0.0.6
-- v0.1.0
-# - haskell-lsp-0_20:
-#     git: e59d3e2c778b07fde3a916046cfa2662ea6107ad
-#     include: false
-# - hashmap:
-#     git: 4e89d4574d538d663bd37f074ef6ef973d14a0f1
-#     include: false
-# - guessAllImports:
-#     git: da92de218a5d8f3b5f2c1f36726e5d079e6dcb79
-#     include: false
-# - haskell-lsp-0_21:
-#     git: 9951f35b08b997fb0565443d7f61400df3a2557d
-#     include: false
-# - interface_files:
-#     git: f804b138dcc99413a173450289d0f1adc084b459
-#     include: true
-# - parse_module_headers:
-#     git: 4f9c7561ee26edbc1ecb00c8ee7655d904f8b134
-#     include: true
-# - haskell-lsp-0_22:
-#     git: 5661348b5e47d2abbd9f6f8d44da8ccab5b807a8
-#     include: false
-# - spaceleaks_hashable:
-#     git: 0c9a0961abbeef851b4117e6408f15a6d46eb1f1
-#     include: true
+# - v0.1.0
 - v0.2.0
-# - shakeSession: 0ff88c6ccccefd1239cf5a82adaa5a675d4ac09d
 - upstream: origin/master
-- cacheGhcSession:
-    git: da29106dc619a81c2dc795c4c0279d0f3724a96f
-    include: true
-- mpickering-stale:
-    git: 1b186bb8091d8c4dd6c0ec62dfbf5cdffc1c48db
-    parent: upstream
 - HEAD
+

--- a/bench/hist.yaml
+++ b/bench/hist.yaml
@@ -9,12 +9,12 @@ ghcideBench: ghcide-bench
 experiments:
     - hover
     - edit
-    # - getDefinition
-    # - "hover after edit"
-    # - "completions after edit"
-    # - "code actions"
-    # - "code actions after edit"
-    # - "documentSymbols after edit"
+    - getDefinition
+    - "hover after edit"
+    - "completions after edit"
+    - "code actions"
+    - "code actions after edit"
+    - "documentSymbols after edit"
 
 # An ordered list of versions to analyze
 versions:

--- a/bench/hist.yaml
+++ b/bench/hist.yaml
@@ -5,6 +5,9 @@ samples: 100
 # Path to the ghcide-bench binary to use for experiments
 ghcideBench: ghcide-bench
 
+# Output folder for the experiments
+outputFolder: bench-hist
+
 # The set of experiments to execute
 experiments:
     - hover

--- a/bench/hist.yaml
+++ b/bench/hist.yaml
@@ -1,0 +1,57 @@
+# The number of samples to run per experiment.
+# At least 100 is recommended in order to observe space leaks
+samples: 100
+
+# Path to the ghcide-bench binary to use for experiments
+ghcideBench: ./ghcide-bench
+
+# The set of experiments to execute
+experiments:
+    - hover
+    - edit
+    # - getDefinition
+    # - "hover after edit"
+    # - "completions after edit"
+    # - "code actions"
+    # - "code actions after edit"
+    # - "documentSymbols after edit"
+
+# An ordered list of versions to analyze
+versions:
+# - v0.0.5
+# - v0.0.6
+- v0.1.0
+# - haskell-lsp-0_20:
+#     git: e59d3e2c778b07fde3a916046cfa2662ea6107ad
+#     include: false
+# - hashmap:
+#     git: 4e89d4574d538d663bd37f074ef6ef973d14a0f1
+#     include: false
+# - guessAllImports:
+#     git: da92de218a5d8f3b5f2c1f36726e5d079e6dcb79
+#     include: false
+# - haskell-lsp-0_21:
+#     git: 9951f35b08b997fb0565443d7f61400df3a2557d
+#     include: false
+# - interface_files:
+#     git: f804b138dcc99413a173450289d0f1adc084b459
+#     include: true
+# - parse_module_headers:
+#     git: 4f9c7561ee26edbc1ecb00c8ee7655d904f8b134
+#     include: true
+# - haskell-lsp-0_22:
+#     git: 5661348b5e47d2abbd9f6f8d44da8ccab5b807a8
+#     include: false
+# - spaceleaks_hashable:
+#     git: 0c9a0961abbeef851b4117e6408f15a6d46eb1f1
+#     include: true
+- v0.2.0
+# - shakeSession: 0ff88c6ccccefd1239cf5a82adaa5a675d4ac09d
+- upstream: origin/master
+- cacheGhcSession:
+    git: da29106dc619a81c2dc795c4c0279d0f3724a96f
+    include: true
+- mpickering-stale:
+    git: 1b186bb8091d8c4dd6c0ec62dfbf5cdffc1c48db
+    parent: upstream
+- HEAD

--- a/bench/hist.yaml
+++ b/bench/hist.yaml
@@ -26,11 +26,11 @@ versions:
 # - <branch>
 # - <commit hash>
 
-# Or in extended form:
+# Or in extended form, where all the fields are optional:
 # - <name>:
-#    - git: <tag/branch/commithash>
-#    - include: true                   # whether to include in comparison graphs
-#    - parent: <tag/branch/commithash> # version to compare with in .diff graphs
+#    git: <tag/branch/commithash>
+#    include: true                   # whether to include in comparison graphs
+#    parent: <tag/branch/commithash> # version to compare with in .diff graphs
 
 
 # - v0.0.5

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -178,6 +178,21 @@ executable benchHist
     buildable: True
     ghc-options: -Wall -Wno-name-shadowing -threaded
     main-is: bench/Hist/Main.hs
+    default-extensions:
+        BangPatterns
+        DeriveFunctor
+        DeriveGeneric
+        GeneralizedNewtypeDeriving
+        LambdaCase
+        NamedFieldPuns
+        OverloadedStrings
+        RecordWildCards
+        ScopedTypeVariables
+        StandaloneDeriving
+        TupleSections
+        TypeApplications
+        ViewPatterns
+
     build-depends:
         aeson,
         base == 4.*,

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -173,6 +173,25 @@ executable ghcide-test-preprocessor
     build-depends:
         base == 4.*
 
+executable benchHist
+    default-language: Haskell2010
+    buildable: True
+    ghc-options: -Wall -Wno-name-shadowing -threaded
+    main-is: bench/Hist/Main.hs
+    build-depends:
+        aeson,
+        base == 4.*,
+        Chart,
+        Chart-diagrams,
+        diagrams,
+        diagrams-svg,
+        directory,
+        extra,
+        filepath,
+        shake,
+        text,
+        yaml
+
 executable ghcide
     if flag(ghc-lib)
       buildable: False

--- a/hie.yaml
+++ b/hie.yaml
@@ -14,5 +14,7 @@ cradle:
               component: "ghcide:test:ghcide-tests"
             - path: "./bench"
               component: "ghcide:bench:ghcide-bench"
+            - path: "bench/Hist"
+              component: "ghcide:exe:benchHist"
             - path: "./test/preprocessor"
               component: "ghcide:exe:ghcide-test-preprocessor"

--- a/hie.yaml
+++ b/hie.yaml
@@ -3,7 +3,7 @@ cradle:
     - path: "./test/data"
       config: { cradle: { none:  } }
     - path: "./"
-      config: 
+      config:
         cradle:
           cabal:
             - path: "./src"
@@ -14,7 +14,7 @@ cradle:
               component: "ghcide:test:ghcide-tests"
             - path: "./bench"
               component: "ghcide:bench:ghcide-bench"
-            - path: "bench/Hist"
+            - path: "./bench/Hist"
               component: "ghcide:exe:benchHist"
             - path: "./test/preprocessor"
               component: "ghcide:exe:ghcide-test-preprocessor"

--- a/hie.yaml.cbl
+++ b/hie.yaml.cbl
@@ -3,13 +3,17 @@ cradle:
     - path: "./test/data"
       config: { cradle: { none:  } }
     - path: "./"
-      config: 
+      config:
         cradle:
           cabal:
             - path: "./src"
               component: "ghcide:lib:ghcide"
             - path: "./exe"
               component: "ghcide:exe:ghcide"
+            - path: "./bench"
+              component: "ghcide:bench:ghcide-bench"
+            - path: "./bench/Hist"
+              component: "ghcide:exe:benchHist"
             - path: "./test"
               component: "ghcide:test:ghcide-tests"
             - path: "./test/preprocessor"

--- a/hie.yaml.stack
+++ b/hie.yaml.stack
@@ -14,5 +14,7 @@ cradle:
               component: "ghcide:test:ghcide-tests"
             - path: "./bench"
               component: "ghcide:bench:ghcide-bench"
+            - path: "bench/Hist"
+              component: "ghcide:exe:benchHist"
             - path: "./test/preprocessor"
               component: "ghcide:exe:ghcide-test-preprocessor"

--- a/hie.yaml.stack
+++ b/hie.yaml.stack
@@ -14,7 +14,7 @@ cradle:
               component: "ghcide:test:ghcide-tests"
             - path: "./bench"
               component: "ghcide:bench:ghcide-bench"
-            - path: "bench/Hist"
+            - path: "./bench/Hist"
               component: "ghcide:exe:benchHist"
             - path: "./test/preprocessor"
               component: "ghcide:exe:ghcide-test-preprocessor"

--- a/stack84.yaml
+++ b/stack84.yaml
@@ -29,6 +29,9 @@ extra-deps:
 - ansi-wl-pprint-0.6.9
 - tasty-1.2.3
 - tasty-rerun-1.1.17
+# For benchHist
+- Chart-1.9.3
+- Chart-diagrams-1.9.3
 
 
 nix:


### PR DESCRIPTION
This adds a new script `benchHist` to automate the running of `ghcide-bench` over multiple versions of the project, and produces `.csv` files and `.svg` graphs with the results. More details in the module header and the README.

By default running `stack exec benchHist` will produce an analysis comparing HEAD with upstream, assuming everything works. The analysis is configurable via a yaml file.

I have uploaded a sample output here: https://github.com/pepeiborra/ghcide/tree/bench-hist-dump/bench-hist 

Some interesting results from the analysis:
- Neil's Hashable PR really hit the leak right in the thunk:
![hashable-edit](https://raw.githubusercontent.com/pepeiborra/ghcide/bench-hist-dump/bench-hist/spaceleaks_hashable/edit.diff.svg)

- Interface files did curb memory usage! 
![interface-hover](https://raw.githubusercontent.com/pepeiborra/ghcide/bench-hist-dump/bench-hist/interface_files/hover.diff.svg)

- But they also made some things twice as slow (and I have a PR coming):
![interface-hover-edit](https://raw.githubusercontent.com/pepeiborra/ghcide/bench-hist-dump/bench-hist/interface_files/hover_after_edit.diff.svg)
 
