### PR TITLE
Cache a ghc session per file of interest

### DIFF
--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -474,7 +474,7 @@ getModSummaryFromImports fp contents = do
         -- To avoid silent issues where something is not processed because the date
         -- has not changed, we make sure that things blow up if they depend on the date.
                 , ms_hsc_src      = sourceType
-                , ms_hspp_buf     = Nothing
+                , ms_hspp_buf     = Just contents
                 , ms_hspp_file    = fp
                 , ms_hspp_opts    = dflags
                 , ms_iface_date   = Nothing

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -474,6 +474,7 @@ getModSummaryFromImports fp contents = do
         -- To avoid silent issues where something is not processed because the date
         -- has not changed, we make sure that things blow up if they depend on the date.
                 , ms_hsc_src      = sourceType
+                -- The contents are used by the GetModSummary rule
                 , ms_hspp_buf     = Just contents
                 , ms_hspp_file    = fp
                 , ms_hspp_opts    = dflags

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -24,6 +24,7 @@ module Development.IDE.Core.Compile
   , loadInterface
   , loadDepModule
   , loadModuleHome
+  , setupFinderCache
   ) where
 
 import Development.IDE.Core.RuleTypes
@@ -116,24 +117,16 @@ computePackageDeps env pkg = do
 
 typecheckModule :: IdeDefer
                 -> HscEnv
-                -> [(ModSummary, (ModIface, Maybe Linkable))]
                 -> ParsedModule
                 -> IO (IdeResult (HscEnv, TcModuleResult))
-typecheckModule (IdeDefer defer) hsc depsIn pm = do
+typecheckModule (IdeDefer defer) hsc pm = do
     fmap (either (, Nothing) (second Just . sequence) . sequence) $
       runGhcEnv hsc $
       catchSrcErrors "typecheck" $ do
-        -- Currently GetDependencies returns things in topological order so A comes before B if A imports B.
-        -- We need to reverse this as GHC gets very unhappy otherwise and complains about broken interfaces.
-        -- Long-term we might just want to change the order returned by GetDependencies
-        let deps = reverse depsIn
-
-        setupFinderCache (map fst deps)
 
         let modSummary = pm_mod_summary pm
             dflags = ms_hspp_opts modSummary
 
-        mapM_ (uncurry loadDepModule . snd) deps
         modSummary' <- initPlugins modSummary
         (warnings, tcm) <- withWarnings "typecheck" $ \tweak ->
             GHC.typecheckModule $ enableTopLevelWarnings

--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -88,6 +88,9 @@ type instance RuleResult GenerateByteCode = Linkable
 -- | A GHC session that we reuse.
 type instance RuleResult GhcSession = HscEnvEq
 
+-- | A GHC session preloaded with all the dependencies
+type instance RuleResult GhcSessionDeps = HscEnvEq
+
 -- | Resolve the imports in a module to the file path of a module
 -- in the same package or the package id of another package.
 type instance RuleResult GetLocatedImports = ([(Located ModuleName, Maybe ArtifactsLocation)], S.Set InstalledUnitId)
@@ -169,6 +172,11 @@ data GhcSession = GhcSession
 instance Hashable GhcSession
 instance NFData   GhcSession
 instance Binary   GhcSession
+
+data GhcSessionDeps = GhcSessionDeps deriving (Eq, Show, Typeable, Generic)
+instance Hashable GhcSessionDeps
+instance NFData   GhcSessionDeps
+instance Binary   GhcSessionDeps
 
 data GetModIfaceFromDisk = GetModIfaceFromDisk
     deriving (Eq, Show, Typeable, Generic)

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -600,7 +600,7 @@ ghcSessionDepsDefinition file = do
             mapM_ (uncurry loadDepModule) inLoadOrder
 
         res <- liftIO $ newHscEnvEq session' []
-        return $ ([], Just res)
+        return ([], Just res)
  where
   unpack HiFileResult{..} bc = (hirModIface, bc)
   uses_th_qq dflags =

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -301,7 +301,7 @@ execRawDepM act =
 -- imports recursively.
 rawDependencyInformation :: [NormalizedFilePath] -> Action RawDependencyInformation
 rawDependencyInformation fs = do
-    (rdi, ss) <- execRawDepM (mapM_ go $ reverse fs)
+    (rdi, ss) <- execRawDepM (mapM_ go fs)
     let bm = IntMap.foldrWithKey (updateBootMap rdi) IntMap.empty ss
     return (rdi { rawBootMap = bm })
   where

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -449,6 +449,8 @@ getSpanInfoRule =
 #if MIN_GHC_API_VERSION(8,6,0) && !defined(GHC_LIB)
         let parsedDeps = []
 #else
+        deps <- maybe (TransitiveDependencies [] [] []) fst <$> useWithStale GetDependencies file
+        let tdeps = transitiveModuleDeps deps
         parsedDeps <- mapMaybe (fmap fst) <$> usesWithStale GetParsedModule tdeps
 #endif
 

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -28,8 +28,10 @@ module Development.IDE.Core.Shake(
     shakeRestart,
     shakeEnqueue,
     shakeProfile,
-    use, useWithStale, useNoFile, uses, usesWithStale,
+    use, useNoFile, uses,
     use_, useNoFile_, uses_,
+    useWithStale, usesWithStale,
+    useWithStale_, usesWithStale_,
     define, defineEarlyCutoff, defineOnDisk, needOnDisk, needOnDisks,
     getDiagnostics, unsafeClearDiagnostics,
     getHiddenDiagnostics,
@@ -555,6 +557,17 @@ use key file = head <$> uses key [file]
 useWithStale :: IdeRule k v
     => k -> NormalizedFilePath -> Action (Maybe (v, PositionMapping))
 useWithStale key file = head <$> usesWithStale key [file]
+
+useWithStale_ :: IdeRule k v
+    => k -> NormalizedFilePath -> Action (v, PositionMapping)
+useWithStale_ key file = head <$> usesWithStale_ key [file]
+
+usesWithStale_ :: IdeRule k v => k -> [NormalizedFilePath] -> Action [(v, PositionMapping)]
+usesWithStale_ key files = do
+    res <- usesWithStale key files
+    case sequence res of
+        Nothing -> liftIO $ throwIO $ BadDependency (show key)
+        Just v -> return v
 
 useNoFile :: IdeRule k v => k -> Action (Maybe v)
 useNoFile key = use key emptyFilePath


### PR DESCRIPTION
I recently discovered that the `.hi` files PR had regressed the performance of `GetSpanInfo` quite noticeably. This is due mostly to a change in the extraction of `spanInfoDoc`s. Prior to the interfaces change, these were mined out of parsed ASTs. `.hi` files don't come with ASTs but instead bundle the haddocks for identifiers. But to be able to use them, we need to:

1. set up a GHC session with all the transitive `.hi` files 
2. rely on [getDocs](https://hackage.haskell.org/package/ghc-8.10.1/docs/GHC.html#v:getDocs) to extract them

Step 1 can be sped up easily by caching a GHC session per module for files of interest, which makes `GetSpanInfo` as speedy as it used to be, as seen in the "hover after edit" experiment.  I was hoping it would also speed up typechecking, but the edit experiment suggests otherwise so I might have missed something.  

Benchmark results (hover becomes much faster, all else stays the same):
```
version              name                         success   samples   startup              setup                 experiment            maxResidency
upstream             hover                        True      100       7.567142767000001    0.0                   0.479372591           218MB
upstream             edit                         True      100       7.953766959          0.0                   25.364602476          217MB
upstream             getDefinition                True      100       8.692988179          0.0                   0.46926602100000003   219MB
upstream             hover after edit             True      100       8.31115918           0.0                   66.021477715          237MB
upstream             completions after edit       True      100       9.410036817          0.0                   33.817070408          222MB
upstream             code actions                 True      100       10.039016802         0.44827246800000004   0.576492419           242MB
upstream             code actions after edit      False     100       7.954712423          0.0                   1.5715171460000001    245MB
upstream             documentSymbols after edit   True      100       9.284543272          0.0                   1.883872325           218MB
module-ghc-session   hover                        True      100       7.223818533          0.0                   0.13876206500000002   228MB
module-ghc-session   edit                         True      100       7.344935921          0.0                   24.669866416          219MB
module-ghc-session   getDefinition                True      100       7.237144228          0.0                   0.119550469           216MB
module-ghc-session   hover after edit             True      100       7.276310433000001    0.0                   29.694541188000002    218MB
module-ghc-session   completions after edit       True      100       7.3100683150000005   0.0                   30.394427346          222MB
module-ghc-session   code actions                 True      100       7.236867787          0.304327993           0.407078469           243MB
module-ghc-session   code actions after edit      False     100       7.397161018          0.0                   0.445487738           242MB
module-ghc-session   documentSymbols after edit   True      100       7.867092457000001    0.0                   1.7937549000000002    216MB
```
