### PR TITLE
Fix crash when writing to a Barrier more than once

### DIFF
--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -496,15 +496,17 @@ newSession IdeState{shakeExtras=ShakeExtras{..}, ..} systemActs userActs = do
     --  The session stays open until 'cancelShakeSession' is called
     let runInShakeSession :: forall a . Action a -> IO (IO a)
         runInShakeSession act = do
-              res <- newEmptyMVar -- almost a Barrier, but we attempt to write more than once
+              res <- newBarrier
               let act' = do
                     -- work gets reenqueued when the Shake session is restarted
                     -- it can happen that a work item finished just as it was reenqueud
-                    -- in that case, returning the already produced value is fine
-                    alreadyDone <- liftIO $ tryReadMVar res
-                    maybe (actionCatch @SomeException (Right <$> act) (pure . Left)) return alreadyDone
-              atomically $ writeTQueue actionQueue (act' >>= liftIO . void . tryPutMVar res)
-              return (readMVar res >>= either throwIO return)
+                    -- in that case, skipping the work is fine
+                    alreadyDone <- liftIO $ isJust <$> waitBarrierMaybe res
+                    unless alreadyDone $ do
+                        x <- actionCatch @SomeException (Right <$> act) (pure . Left)
+                        liftIO $ signalBarrier res x
+              atomically $ writeTQueue actionQueue act'
+              return (waitBarrier res >>= either throwIO return)
 
     --  Cancelling is required to flush the Shake database when either
     --  the filesystem or the Ghc configuration have changed


### PR DESCRIPTION
This fixes a race condition in the ShakeSession logic for reenqueuing user actions.