### PR TITLE
 Remove `Strict` from the language extensions used for code actions

### DIFF
--- a/src/Development/IDE/Plugin/CodeAction.hs
+++ b/src/Development/IDE/Plugin/CodeAction.hs
@@ -266,7 +266,11 @@ suggestAddExtension Diagnostic{_range=_range,..}
 
 -- | All the GHC extensions
 ghcExtensions :: Map.HashMap T.Text Extension
-ghcExtensions = Map.fromList . map ( ( T.pack . flagSpecName ) &&& flagSpecFlag ) $ xFlags
+ghcExtensions = Map.fromList . filter notStrictFlag . map ( ( T.pack . flagSpecName ) &&& flagSpecFlag ) $ xFlags
+  where
+    -- Strict often causes false positives, as in Data.Map.Strict imports.
+    -- See discussion at https://github.com/digital-asset/ghcide/pull/638
+    notStrictFlag (name, _) = name /= "Strict"
 
 suggestModuleTypo :: Diagnostic -> [(T.Text, [TextEdit])]
 suggestModuleTypo Diagnostic{_range=_range,..}


### PR DESCRIPTION
This code action uses an unreliable heuristic, i.e. substring matching
for all existing language extensions.
The "quickfix" LSP action chooses an arbitrary code action from the
list, presumably the first in the list.

As an example, the redundant import

`import Data.Map.Strict`

will trigger the suggestion to add the language extension "Strict".
Moving this suggestion to the end of the list reduces the likelihood
for false positives.

----

Since selection of the quickfix action happens outside of ghcide, there's probably a better solution.
Any suggestions? A better workaround could be to check for the language extension's name's presence in the offending code.

I added a test but it fails and I don't see the definitions of `getCodeActions` and `executeCodeAction`. Some advice would be appreciated!