### PR TITLE
Finer dependencies for GhcSessionFun

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -18,6 +18,7 @@ import Control.Concurrent.Extra
 import Control.Exception.Safe
 import Control.Monad.Extra
 import Control.Monad.IO.Class
+import Data.Bifunctor (Bifunctor(second))
 import Data.Default
 import Data.Either
 import Data.Foldable (for_)
@@ -122,7 +123,7 @@ main = do
         runLanguageServer options (pluginHandler plugins) onInitialConfiguration onConfigurationChange $ \getLspId event vfs caps wProg wIndefProg -> do
             t <- t
             hPutStrLn stderr $ "Started LSP server in " ++ showDuration t
-            sessionLoader <- loadSessionShake dir
+            sessionLoader <- loadSession dir
             let options = (defaultIdeOptions sessionLoader)
                     { optReportProgress = clientSupportsProgress caps
                     , optShakeProfiling = argsShakeProfiling
@@ -155,7 +156,7 @@ main = do
         vfs <- makeVFSHandle
         debouncer <- newAsyncDebouncer
         let dummyWithProg _ _ f = f (const (pure ()))
-        sessionLoader <- loadSessionShake dir
+        sessionLoader <- loadSession dir
         ide <- initialise def mainRule (pure $ IdInt 0) (showEvent lock) dummyWithProg (const (const id)) (logger minBound) debouncer (defaultIdeOptions sessionLoader)  vfs
 
         putStrLn "\nStep 4/4: Type checking the files"
@@ -225,16 +226,10 @@ targetToFile _ (TargetFile f _) = do
 setNameCache :: IORef NameCache -> HscEnv -> HscEnv
 setNameCache nc hsc = hsc { hsc_NC = nc }
 
-loadSessionShake :: FilePath -> IO (Action (Int, FilePath -> Action (IdeResult HscEnvEq)))
-loadSessionShake fp = do
-  res <- loadSession fp
-  -- the classic triple fmap in action
-  return $ (fmap.fmap.fmap) liftIO res
-
 -- | This is the key function which implements multi-component support. All
 -- components mapping to the same hie.yaml file are mapped to the same
 -- HscEnv which is updated as new components are discovered.
-loadSession :: FilePath -> IO (Action (Int, FilePath -> IO (IdeResult HscEnvEq)))
+loadSession :: FilePath -> IO (Action IdeGhcSession)
 loadSession dir = do
   -- Mapping from hie.yaml file to HscEnv, one per hie.yaml file
   hscEnvs <- newVar Map.empty :: IO (Var HieMap)
@@ -242,7 +237,9 @@ loadSession dir = do
   fileToFlags <- newVar Map.empty :: IO (Var FlagsMap)
   -- Version of the mappings above
   version <- newVar 0
-  let returnWithVersion x = (,x) <$> liftIO (readVar version)
+  let returnWithVersion fun = IdeGhcSession fun <$> liftIO (readVar version)
+  let invalidateShakeCache = do
+        modifyVar_ version (return . succ)
   -- This caches the mapping from Mod.hs -> hie.yaml
   cradleLoc <- liftIO $ memoIO $ \v -> do
       res <- findCradle v
@@ -256,13 +253,13 @@ loadSession dir = do
   installationCheck <- ghcVersionChecker libdir
 
   dummyAs <- async $ return (error "Uninitialised")
-  runningCradle <- newVar dummyAs :: IO (Var (Async (IdeResult HscEnvEq)))
+  runningCradle <- newVar dummyAs :: IO (Var (Async (IdeResult HscEnvEq,[FilePath])))
 
   case installationCheck of
     InstallationNotFound{..} ->
         error $ "GHC installation not found in libdir: " <> libdir
     InstallationMismatch{..} ->
-        return $ returnWithVersion $ \fp -> return ([renderPackageSetupException compileTime fp GhcVersionMismatch{..}], Nothing)
+        return $ returnWithVersion $ \fp -> return (([renderPackageSetupException compileTime fp GhcVersionMismatch{..}], Nothing),[])
     InstallationChecked compileTime ghcLibCheck -> return $ do
       ShakeExtras{logger, eventer, restartShakeSession, withIndefiniteProgress} <- getShakeExtras
       IdeOptions{optTesting = IdeTesting optTesting} <- getIdeOptions
@@ -278,7 +275,8 @@ loadSession dir = do
             hscEnv <- emptyHscEnv
             (df, targets) <- evalGhcEnv hscEnv $
                 setOptions opts (hsc_dflags hscEnv)
-            dep_info <- getDependencyInfo (componentDependencies opts ++ maybeToList hieYaml)
+            let deps = (componentDependencies opts ++ maybeToList hieYaml)
+            dep_info <- getDependencyInfo deps
             -- Now lookup to see whether we are combining with an existing HscEnv
             -- or making a new one. The lookup returns the HscEnv and a list of
             -- information about other components loaded into the HscEnv
@@ -338,7 +336,8 @@ loadSession dir = do
                 --   existing packages
                 pure (Map.insert hieYaml (newHscEnv, new_deps) m, (newHscEnv, head new_deps', tail new_deps'))
 
-      let session :: (Maybe FilePath, NormalizedFilePath, ComponentOptions) -> IO (IdeResult HscEnvEq)
+
+      let session :: (Maybe FilePath, NormalizedFilePath, ComponentOptions) -> IO (IdeResult HscEnvEq,[FilePath])
           session (hieYaml, cfp, opts) = do
             (hscEnv, new, old_deps) <- packageSetup (hieYaml, cfp, opts)
             -- Make a map from unit-id to DynFlags, this is used when trying to
@@ -359,12 +358,12 @@ loadSession dir = do
                 pure $ Map.insert hieYaml (HM.fromList (cs ++ cached_targets)) var
 
             -- Invalidate all the existing GhcSession build nodes by restarting the Shake session
-            modifyVar_ version (return . succ)
+            invalidateShakeCache
             restartShakeSession [kick]
 
-            return (fst res)
+            return (second Map.keys res)
 
-      let consultCradle :: Maybe FilePath -> FilePath -> IO (IdeResult HscEnvEq)
+      let consultCradle :: Maybe FilePath -> FilePath -> IO (IdeResult HscEnvEq, [FilePath])
           consultCradle hieYaml cfp = do
              when optTesting $ eventer $ notifyCradleLoaded cfp
              logInfo logger $ T.pack ("Consulting the cradle for " <> show cfp)
@@ -389,10 +388,11 @@ loadSession dir = do
                  let res = (map (renderCradleError ncfp) err, Nothing)
                  modifyVar_ fileToFlags $ \var -> do
                    pure $ Map.insertWith HM.union hieYaml (HM.singleton ncfp (res, dep_info)) var
-                 return res
+                 return (res,[])
 
       -- This caches the mapping from hie.yaml + Mod.hs -> [String]
-      let sessionOpts :: (Maybe FilePath, FilePath) -> IO (IdeResult HscEnvEq)
+      -- Returns the Ghc session and the cradle dependencies
+      let sessionOpts :: (Maybe FilePath, FilePath) -> IO (IdeResult HscEnvEq, [FilePath])
           sessionOpts (hieYaml, file) = do
             v <- fromMaybe HM.empty . Map.lookup hieYaml <$> readVar fileToFlags
             cfp <- canonicalizePath file
@@ -407,18 +407,18 @@ loadSession dir = do
                     -- Keep the same name cache
                     modifyVar_ hscEnvs (return . Map.adjust (\(h, _) -> (h, [])) hieYaml )
                     consultCradle hieYaml cfp
-                  else return opts
+                  else return (opts, Map.keys old_di)
               Nothing -> consultCradle hieYaml cfp
 
       -- The main function which gets options for a file. We only want one of these running
       -- at a time. Therefore the IORef contains the currently running cradle, if we try
       -- to get some more options then we wait for the currently running action to finish
       -- before attempting to do so.
-      let getOptions :: FilePath -> IO (IdeResult HscEnvEq)
+      let getOptions :: FilePath -> IO (IdeResult HscEnvEq, [FilePath])
           getOptions file = do
               hieYaml <- cradleLoc file
               sessionOpts (hieYaml, file) `catch` \e ->
-                  return ([renderPackageSetupException compileTime file e], Nothing)
+                  return (([renderPackageSetupException compileTime file e], Nothing),[])
 
       returnWithVersion $ \file -> do
         liftIO $ join $ mask_ $ modifyVar runningCradle $ \as -> do

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -275,7 +275,7 @@ loadSession dir = do
             hscEnv <- emptyHscEnv
             (df, targets) <- evalGhcEnv hscEnv $
                 setOptions opts (hsc_dflags hscEnv)
-            let deps = (componentDependencies opts ++ maybeToList hieYaml)
+            let deps = componentDependencies opts ++ maybeToList hieYaml
             dep_info <- getDependencyInfo deps
             -- Now lookup to see whether we are combining with an existing HscEnv
             -- or making a new one. The lookup returns the HscEnv and a list of

--- a/src/Development/IDE/Types/Options.hs
+++ b/src/Development/IDE/Types/Options.hs
@@ -14,6 +14,7 @@ module Development.IDE.Types.Options
   , IdePkgLocationOptions(..)
   , defaultIdeOptions
   , IdeResult
+  , IdeGhcSession(..)
   ) where
 
 import Development.Shake
@@ -23,12 +24,22 @@ import           GhcPlugins                     as GHC hiding (fst3, (<>))
 import qualified Language.Haskell.LSP.Types.Capabilities as LSP
 import qualified Data.Text as T
 import Development.IDE.Types.Diagnostics
+import Control.DeepSeq (NFData(..))
+
+data IdeGhcSession = IdeGhcSession
+  { loadSessionFun :: FilePath -> IO (IdeResult HscEnvEq, [FilePath])
+  -- ^ Returns the Ghc session and the cradle dependencies
+  , sessionVersion :: !Int
+  }
+
+instance Show IdeGhcSession where show _ = "IdeGhcSession"
+instance NFData IdeGhcSession where rnf !_ = ()
 
 data IdeOptions = IdeOptions
   { optPreprocessor :: GHC.ParsedSource -> IdePreprocessedSource
     -- ^ Preprocessor to run over all parsed source trees, generating a list of warnings
     --   and a list of errors, along with a new parse tree.
-  , optGhcSession :: Action (Int, FilePath -> Action (IdeResult HscEnvEq))
+  , optGhcSession :: Action IdeGhcSession
     -- ^ Setup a GHC session for a given file, e.g. @Foo.hs@.
     --   For the same 'ComponentOptions' from hie-bios, the resulting function will be applied once per file.
     --   It is desirable that many files get the same 'HscEnvEq', so that more IDE features work.
@@ -80,7 +91,7 @@ clientSupportsProgress :: LSP.ClientCapabilities -> IdeReportProgress
 clientSupportsProgress caps = IdeReportProgress $ Just True ==
     (LSP._workDoneProgress =<< LSP._window (caps :: LSP.ClientCapabilities))
 
-defaultIdeOptions :: Action (Int, FilePath -> Action (IdeResult HscEnvEq)) -> IdeOptions
+defaultIdeOptions :: Action IdeGhcSession -> IdeOptions
 defaultIdeOptions session = IdeOptions
     {optPreprocessor = IdePreprocessedSource [] []
     ,optGhcSession = session

--- a/src/Development/IDE/Types/Options.hs
+++ b/src/Development/IDE/Types/Options.hs
@@ -28,7 +28,7 @@ data IdeOptions = IdeOptions
   { optPreprocessor :: GHC.ParsedSource -> IdePreprocessedSource
     -- ^ Preprocessor to run over all parsed source trees, generating a list of warnings
     --   and a list of errors, along with a new parse tree.
-  , optGhcSession :: Action (FilePath -> Action (IdeResult HscEnvEq))
+  , optGhcSession :: Action (Int, FilePath -> Action (IdeResult HscEnvEq))
     -- ^ Setup a GHC session for a given file, e.g. @Foo.hs@.
     --   For the same 'ComponentOptions' from hie-bios, the resulting function will be applied once per file.
     --   It is desirable that many files get the same 'HscEnvEq', so that more IDE features work.
@@ -80,7 +80,7 @@ clientSupportsProgress :: LSP.ClientCapabilities -> IdeReportProgress
 clientSupportsProgress caps = IdeReportProgress $ Just True ==
     (LSP._workDoneProgress =<< LSP._window (caps :: LSP.ClientCapabilities))
 
-defaultIdeOptions :: Action (FilePath -> Action (IdeResult HscEnvEq)) -> IdeOptions
+defaultIdeOptions :: Action (Int, FilePath -> Action (IdeResult HscEnvEq)) -> IdeOptions
 defaultIdeOptions session = IdeOptions
     {optPreprocessor = IdePreprocessedSource [] []
     ,optGhcSession = session

--- a/src/Development/IDE/Types/Options.hs
+++ b/src/Development/IDE/Types/Options.hs
@@ -30,6 +30,7 @@ data IdeGhcSession = IdeGhcSession
   { loadSessionFun :: FilePath -> IO (IdeResult HscEnvEq, [FilePath])
   -- ^ Returns the Ghc session and the cradle dependencies
   , sessionVersion :: !Int
+  -- ^ Used as Shake key, versions must be unique and not reused
   }
 
 instance Show IdeGhcSession where show _ = "IdeGhcSession"

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -491,11 +491,12 @@ watchedFilesTests = testGroup "watched files"
       watchedFileRegs <- getWatchedFilesSubscriptionsUntil @PublishDiagnosticsNotification
 
       -- Expect 4 subscriptions (A does not get any because it's VFS):
+      --  - /path-to-workspace/hie.yaml
       --  - /path-to-workspace/WatchedFilesMissingModule.hs
       --  - /path-to-workspace/WatchedFilesMissingModule.lhs
       --  - /path-to-workspace/src/WatchedFilesMissingModule.hs
       --  - /path-to-workspace/src/WatchedFilesMissingModule.lhs
-      liftIO $ length watchedFileRegs @?= 4
+      liftIO $ length watchedFileRegs @?= 5
 
   , testSession' "non workspace file" $ \sessionDir -> do
       liftIO $ writeFile (sessionDir </> "hie.yaml") "cradle: {direct: {arguments: [\"-i/tmp\"]}}"
@@ -503,9 +504,10 @@ watchedFilesTests = testGroup "watched files"
       watchedFileRegs <- getWatchedFilesSubscriptionsUntil @PublishDiagnosticsNotification
 
       -- Expect 2 subscriptions (/tmp does not get any as it is out of the workspace):
+      --  - /path-to-workspace/hie.yaml
       --  - /path-to-workspace/WatchedFilesMissingModule.hs
       --  - /path-to-workspace/WatchedFilesMissingModule.lhs
-      liftIO $ length watchedFileRegs @?= 2
+      liftIO $ length watchedFileRegs @?= 3
 
   -- TODO add a test for didChangeWorkspaceFolder
   ]


### PR DESCRIPTION
Now `GhcSession` tracks the component dependencies, and `GhcSessionIO` (no file) tracks the set of components. Since `GhcSession` has a dependency on `GhcSessionIO`, this works out as intended: if the set of components changes, all the Ghc sessions become invalidated. Otherwise, a Ghc session is invalidated only when the component dependencies (e.g. the Cabal file) change.

Another 10% perf improvement.

Fixes #619 

Benchmarks where HEAD is this patch, upstream is the previous master:
```
version    name                         success   samples   startup              setup                experiment           maxResidency
upstream   hover                        True      100       10.008805828         0.0                  1.0496357980000002   138MB
upstream   edit                         True      100       10.342245301         0.0                  40.515747643000005   137MB
upstream   getDefinition                True      100       20.589914577000002   0.0                  0.537914714          324MB
upstream   hover after edit             True      100       9.944694886          0.0                  89.364840677         156MB
upstream   completions after edit       True      100       9.465573668000001    0.0                  50.609864630000004   148MB
upstream   code actions                 True      100       9.376972059          0.6628133180000001   0.96582895           166MB
upstream   code actions after edit      True      100       10.779993297         0.0                  41.802328869         171MB
upstream   documentSymbols after edit   True      100       9.692719622          0.0                  3.1590869070000003   133MB
HEAD       hover                        True      100       10.359037769         0.0                  0.8585313830000001   137MB
HEAD       edit                         True      100       9.726820669          0.0                  31.940400373000003   137MB
HEAD       getDefinition                True      100       21.827025083000002   0.0                  0.648860783          318MB
HEAD       hover after edit             True      100       9.524636392000001    0.0                  80.23256079800001    156MB
HEAD       completions after edit       True      100       10.814269279000001   0.0                  43.996691731000006   143MB
HEAD       code actions                 True      100       9.39776919           0.595851581          0.9932212890000001   166MB
HEAD       code actions after edit      True      100       9.59566279           0.0                  38.154787442         171MB
HEAD       documentSymbols after edit   True      100       9.920586814          0.0                  3.0366749910000004   135MB
```
Graphs here: https://github.com/pepeiborra/ghcide/tree/GhcSession-alwaysRerun-benchmarks/bench-hist

![Edit experiment](https://raw.githubusercontent.com/pepeiborra/ghcide/GhcSession-alwaysRerun-benchmarks/bench-hist/edit.svg)

![Hover after edit experiment](https://raw.githubusercontent.com/pepeiborra/ghcide/GhcSession-alwaysRerun-benchmarks/bench-hist/hover_after_edit.svg)
