### PR TITLE
Code action: add constraint

### DIFF
--- a/src/Development/IDE/Plugin/CodeAction.hs
+++ b/src/Development/IDE/Plugin/CodeAction.hs
@@ -472,8 +472,8 @@ suggestInstanceConstraint contents Diagnostic {..} missingConstraint
   | otherwise = []
     where
       findExistingConstraints :: T.Text -> T.Text
-      findExistingConstraints =
-        T.lines >>> flip (!!) 1 >>> T.strip >>> T.replace "from the context: " ""
+      findExistingConstraints t =
+        T.replace "from the context: " "" . T.strip $ T.lines t !! 1
 
       readPositionNumber :: T.Text -> Int
       readPositionNumber = T.unpack >>> read >>> pred
@@ -529,7 +529,7 @@ suggestFunctionConstraint contents Diagnostic{..} missingConstraint
       findExistingConstraints :: T.Text -> Maybe T.Text
       findExistingConstraints message =
         if message =~ ("from the context:" :: String)
-           then matchRegex message "\\. ([^=]+)" <&> head <&> T.strip
+           then fmap (T.strip . head) $ matchRegex message "\\. ([^=]+)"
            else Nothing
 
       buildNewConstraints :: T.Text -> Maybe T.Text -> T.Text

--- a/src/Development/IDE/Plugin/CodeAction.hs
+++ b/src/Development/IDE/Plugin/CodeAction.hs
@@ -421,8 +421,10 @@ normalizeConstraints existingConstraints constraint =
                            else "(" <> existingConstraints
    in constraintsInit <> ", " <> constraint <> ")"
 
+-- | Suggests a constraint for an instance declaration for which a constraint is missing.
 suggestInstanceConstraint :: Maybe T.Text -> Diagnostic -> [(T.Text, [TextEdit])]
 suggestInstanceConstraint contents Diagnostic {..}
+-- Suggests a constraint for an instance declaration with no existing constraints.
 -- • No instance for (Eq a) arising from a use of ‘==’
 --   Possible fix: add (Eq a) to the context of the instance declaration
 -- • In the expression: x == y
@@ -439,6 +441,8 @@ suggestInstanceConstraint contents Diagnostic {..}
         title = "Add `" <> constraint <> "` to the context of the instance declaration"
         newConstraint = constraint <> " => "
      in [(title, [TextEdit range newConstraint])]
+
+-- Suggests a constraint for an instance declaration with one or more existing constraints.
 -- • Could not deduce (Eq b) arising from a use of ‘==’
 --   from the context: Eq a
 --     bound by the instance declaration at /path/to/Main.hs:7:10-32
@@ -475,8 +479,10 @@ findTypeSignatureLine :: T.Text -> T.Text -> Int
 findTypeSignatureLine contents typeSignatureName =
   T.splitOn (typeSignatureName <> " :: ") contents & head & T.lines & length
 
+-- | Suggests a constraint for a type signature for which a constraint is missing.
 suggestFunctionConstraint :: Maybe T.Text -> Diagnostic -> [(T.Text, [TextEdit])]
 suggestFunctionConstraint contents Diagnostic{..}
+-- Suggests a constraint for a type signature with any number of existing constraints.
 -- • No instance for (Eq a) arising from a use of ‘==’
 --   Possible fix:
 --     add (Eq a) to the context of

--- a/src/Development/IDE/Plugin/CodeAction.hs
+++ b/src/Development/IDE/Plugin/CodeAction.hs
@@ -473,7 +473,7 @@ suggestInstanceConstraint contents Diagnostic {..}
       readPositionNumber = T.unpack >>> read >>> pred
 
 findTypeSignatureName :: T.Text -> Maybe T.Text
-findTypeSignatureName t = matchRegex t "([a-zA-Z0-9]+) :: " <&> head
+findTypeSignatureName t = matchRegex t "\\n\\s*(.+) :: " <&> head
 
 findTypeSignatureLine :: T.Text -> T.Text -> Int
 findTypeSignatureLine contents typeSignatureName =

--- a/src/Development/IDE/Plugin/CodeAction.hs
+++ b/src/Development/IDE/Plugin/CodeAction.hs
@@ -460,7 +460,7 @@ suggestInstanceConstraint contents Diagnostic {..}
         constraintFirstChar = readPositionNumber constraintFirstCharStr
         startOfConstraint = Position instanceLine constraintFirstChar
         endOfConstraint = Position instanceLine $
-          constraintFirstChar + (T.length existingConstraints)
+          constraintFirstChar + T.length existingConstraints
         range = Range startOfConstraint endOfConstraint
         title = "Add `" <> constraint <> "` to the context of the instance declaration"
      in [(title, [TextEdit range newConstraints])]

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -481,7 +481,7 @@ codeActionTests = testGroup "code actions"
   , addSigActionTests
   , insertNewDefinitionTests
   , deleteUnusedDefinitionTests
-  , addConstraintTests
+  , addInstanceConstraintTests
   ]
 
 codeLensesTests :: TestTree
@@ -1329,11 +1329,11 @@ fillTypedHoleTests = let
 #endif
   ]
 
-addConstraintTests :: TestTree
-addConstraintTests = let
-  sourceCode :: Maybe T.Text -> T.Text
-  sourceCode mConstraint =
-    let constraint = maybe "" (\c -> "(" <> c <> ") => ") mConstraint
+addInstanceConstraintTests :: TestTree
+addInstanceConstraintTests = let
+  missingConstraintSourceCode :: Maybe T.Text -> T.Text
+  missingConstraintSourceCode mConstraint =
+    let constraint = maybe "" (<> " => ") mConstraint
      in T.unlines
     [ "module Testing where"
     , ""
@@ -1343,20 +1343,54 @@ addConstraintTests = let
     , "  (Wrap x) == (Wrap y) = x == y"
     ]
 
-  check :: T.Text -> TestTree
-  check actionTitle = testSession (T.unpack actionTitle) $ do
-    let originalCode = sourceCode Nothing
-    let expectedCode = sourceCode $ Just "Eq a"
+  incompleteConstraintSourceCode :: Maybe T.Text -> T.Text
+  incompleteConstraintSourceCode mConstraint =
+    let constraint = maybe "Eq a" (\c -> "(Eq a, " <> c <> ")")  mConstraint
+     in T.unlines
+    [ "module Testing where"
+    , ""
+    , "data Pair a b = Pair a b"
+    , ""
+    , "instance " <> constraint <> " => Eq (Pair a b) where"
+    , "  (Pair x y) == (Pair x' y') = x == x' && y == y'"
+    ]
+
+  incompleteConstraintSourceCode2 :: Maybe T.Text -> T.Text
+  incompleteConstraintSourceCode2 mConstraint =
+    let constraint = maybe "(Eq a, Eq b)" (\c -> "(Eq a, Eq b, " <> c <> ")")  mConstraint
+     in T.unlines
+    [ "module Testing where"
+    , ""
+    , "data Three a b c = Three a b c"
+    , ""
+    , "instance " <> constraint <> " => Eq (Three a b c) where"
+    , "  (Three x y z) == (Three x' y' z') = x == x' && y == y' && z == z'"
+    ]
+
+  check :: T.Text -> T.Text -> T.Text -> TestTree
+  check actionTitle originalCode expectedCode = testSession (T.unpack actionTitle) $ do
     doc <- createDoc "Testing.hs" "haskell" originalCode
     _ <- waitForDiagnostics
-    actionsOrCommands <- getCodeActions doc (Range (Position 6 0) (Position 6 maxBound))
+    actionsOrCommands <- getCodeActions doc (Range (Position 6 0) (Position 6 68))
     chosenAction <- liftIO $ pickActionWithTitle actionTitle actionsOrCommands
     executeCodeAction chosenAction
     modifiedCode <- documentContents doc
     liftIO $ expectedCode @=? modifiedCode
 
   in testGroup "add constraint"
-  [ check "Add `(Eq a)` to the context of the instance declaration" ]
+  [ check
+    "Add `Eq a` to the context of the instance declaration"
+    (missingConstraintSourceCode Nothing)
+    (missingConstraintSourceCode $ Just "Eq a")
+  , check
+    "Add `Eq b` to the context of the instance declaration"
+    (incompleteConstraintSourceCode Nothing)
+    (incompleteConstraintSourceCode $ Just "Eq b")
+  , check
+    "Add `Eq c` to the context of the instance declaration"
+    (incompleteConstraintSourceCode2 Nothing)
+    (incompleteConstraintSourceCode2 $ Just "Eq c")
+  ]
 
 addSigActionTests :: TestTree
 addSigActionTests = let


### PR DESCRIPTION
This PR adds code actions to generate suggestions for missing constraints, both for `instance`s declaration and type signatures. I've handled cases where no, one or more other constraints are already declared.

I've also introduced operators like `>>>`, `&`, `<&>` in order to compose from left to right (like the code flows from left to right) and to have code more easier to read and to reason about. I'm mentioning this because I didn't see them used in the code (at least not in the files I changed), so if for some reason they are not welcome, I'll change them.

This closes https://github.com/digital-asset/ghcide/issues/345.