### PR TITLE
Delete unused top level binding code action

### DIFF
--- a/src/Development/IDE/GHC/Compat.hs
+++ b/src/Development/IDE/GHC/Compat.hs
@@ -32,6 +32,8 @@ module Development.IDE.GHC.Compat(
     pattern InstD,
     pattern TyClD,
     pattern ValD,
+    pattern SigD,
+    pattern TypeSig,
     pattern ClassOpSig,
     pattern IEThingAll,
     pattern IEThingWith,
@@ -52,7 +54,7 @@ import Packages
 
 import qualified GHC
 import GHC hiding (
-      ClassOpSig, DerivD, ForD, IEThingAll, IEThingWith, InstD, TyClD, ValD, ModLocation
+      ClassOpSig, DerivD, ForD, IEThingAll, IEThingWith, InstD, TyClD, ValD, SigD, TypeSig, ModLocation
 #if MIN_GHC_API_VERSION(8,6,0)
     , getConArgs
 #endif
@@ -156,6 +158,22 @@ pattern TyClD x <-
     GHC.TyClD _ x
 #else
     GHC.TyClD x
+#endif
+
+pattern SigD :: Sig p -> HsDecl p
+pattern SigD x <-
+#if MIN_GHC_API_VERSION(8,6,0)
+    GHC.SigD _ x
+#else
+    GHC.SigD x
+#endif
+
+pattern TypeSig :: [Located (IdP p)] -> LHsSigWcType p -> Sig p
+pattern TypeSig x y <-
+#if MIN_GHC_API_VERSION(8,6,0)
+    GHC.TypeSig _ x y
+#else
+    GHC.TypeSig x y
 #endif
 
 pattern ClassOpSig :: Bool -> [Located (IdP pass)] -> LHsSigType pass -> Sig pass

--- a/src/Development/IDE/Plugin/CodeAction.hs
+++ b/src/Development/IDE/Plugin/CodeAction.hs
@@ -191,6 +191,7 @@ suggestDeleteTopBinding ParsedModule{pm_parsed_source = L _ HsModule{hsmodDecls}
                         . sortLocated
                         $ hsmodDecls
           sameName = filter (matchesBindingName (T.unpack name) . snd) allTopLevel
+    , not (null sameName)
             = [("Delete ‘" <> name <> "’", flip TextEdit "" . toNextBinding allTopLevel . fst <$> sameName )]
     | otherwise = []
     where

--- a/src/Development/IDE/Plugin/CodeAction.hs
+++ b/src/Development/IDE/Plugin/CodeAction.hs
@@ -161,6 +161,7 @@ suggestAction dflags packageExports ideOptions parsedModule text diag = concat
     ++ suggestDeleteTopBinding pm diag
     | Just pm <- [parsedModule]]
 
+
 suggestRemoveRedundantImport :: ParsedModule -> Maybe T.Text -> Diagnostic -> [(T.Text, [TextEdit])]
 suggestRemoveRedundantImport ParsedModule{pm_parsed_source = L _  HsModule{hsmodImports}} contents Diagnostic{_range=_range,..}
 --     The qualified import of ‘many’ from module ‘Control.Applicative’ is redundant
@@ -195,7 +196,7 @@ suggestDeleteTopBinding ParsedModule{pm_parsed_source = L _ HsModule{hsmodDecls}
 
       matchesBindingName :: HsDecl GhcPs -> String -> Bool
       matchesBindingName (ValD FunBind {fun_id=L _ x}) b = showSDocUnsafe (ppr x) == b
-      matchesBindingName (SigD _ (TypeSig _ (L _ x:_) _)) b = showSDocUnsafe (ppr x) == b
+      matchesBindingName (SigD (TypeSig (L _ x:_) _)) b = showSDocUnsafe (ppr x) == b
       matchesBindingName _ _ = False
 
 suggestReplaceIdentifier :: Maybe T.Text -> Diagnostic -> [(T.Text, [TextEdit])]

--- a/src/Development/IDE/Plugin/CodeAction.hs
+++ b/src/Development/IDE/Plugin/CodeAction.hs
@@ -194,7 +194,7 @@ suggestDeleteTopBinding ParsedModule{pm_parsed_source = L _ HsModule{hsmodDecls}
       nextLine r = r {_end = (_end r) {_line = (_line . _end $ r) + 1, _character = 0}}
 
       matchesBindingName :: HsDecl GhcPs -> String -> Bool
-      matchesBindingName (ValD (FunBind {fun_id=L _ x})) b = showSDocUnsafe (ppr x) == b
+      matchesBindingName (ValD FunBind {fun_id=L _ x}) b = showSDocUnsafe (ppr x) == b
       matchesBindingName (SigD _ (TypeSig _ (L _ x:_) _)) b = showSDocUnsafe (ppr x) == b
       matchesBindingName _ _ = False
 

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -1148,35 +1148,63 @@ insertNewDefinitionTests = testGroup "insert new definition actions"
 
 deleteUnusedDefinitionTests :: TestTree
 deleteUnusedDefinitionTests = testGroup "delete unused definition action"
-  [ testSession "delete unused top level binding" $ do
-      let source = T.unlines [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
-                             , "module A (some) where"
-                             , ""
-                             , "f :: Int -> Int"
-                             , "f 1 = let a = 1"
-                             , "      in a"
-                             , "f 2 = 2"
-                             , ""
-                             , "some = ()"
-                             ]
-      docId <- createDoc "A.hs" "haskell" source
-      expectDiagnostics [ ("A.hs", [(DsWarning, (4, 0), "not used")]) ]
-
-      Just (CACodeAction action@CodeAction { _title = actionTitle })
-                  <- find (\(CACodeAction CodeAction{_title=x}) -> "Delete" `T.isPrefixOf` x )
-                     <$> getCodeActions docId (R 0 0 0 0)
-
-      liftIO $ actionTitle @?= "Delete ‘f’"
-      executeCodeAction action
-      contentAfterAction <- documentContents docId
-      liftIO $ contentAfterAction @?= T.unlines [
+  [ testSession "delete unused top level binding" $
+    testFor
+    (T.unlines [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
+               , "module A (some) where"
+               , ""
+               , "f :: Int -> Int"
+               , "f 1 = let a = 1"
+               , "      in a"
+               , "f 2 = 2"
+               , ""
+               , "some = ()"
+               ])
+    (4, 0)
+    "Delete ‘f’"
+    (T.unlines [
         "{-# OPTIONS_GHC -Wunused-top-binds #-}"
         , "module A (some) where"
         , ""
+        , "some = ()"
+        ])
+
+  , testSession "delete unused top level binding defined in infix form" $
+    testFor
+    (T.unlines [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
+               , "module A (some) where"
+               , ""
+               , "myPlus :: Int -> Int -> Int"
+               , "a `myPlus` b = a + b"
+               , ""
+               , "some = ()"
+               ])
+    (4, 2)
+    "Delete ‘myPlus’"
+    (T.unlines [
+        "{-# OPTIONS_GHC -Wunused-top-binds #-}"
+        , "module A (some) where"
         , ""
         , "some = ()"
-        ]
+      ])
   ]
+  where
+    testFor source pos expectedTitle expectedResult = do
+      docId <- createDoc "A.hs" "haskell" source
+      expectDiagnostics [ ("A.hs", [(DsWarning, pos, "not used")]) ]
+
+      (action, title) <- extractCodeAction docId "Delete"
+
+      liftIO $ title @?= expectedTitle
+      executeCodeAction action
+      contentAfterAction <- documentContents docId
+      liftIO $ contentAfterAction @?= expectedResult
+
+    extractCodeAction docId actionPrefix = do
+      Just (CACodeAction action@CodeAction { _title = actionTitle })
+                  <- find (\(CACodeAction CodeAction{_title=x}) -> actionPrefix `T.isPrefixOf` x)
+                     <$> getCodeActions docId (R 0 0 0 0)
+      return (action, actionTitle)
 
 
 fixConstructorImportTests :: TestTree


### PR DESCRIPTION
This is my first contribution. My goal is contribute to haskell-language-server / ghcide constantly. This adds a code action that deletes unused top level binding.

Please, let me know how this should be improved.

This closes #54 (I think)