### PR TITLE
Fix debouncer for 0 delay

### DIFF
--- a/src/Development/IDE/Core/Debouncer.hs
+++ b/src/Development/IDE/Core/Debouncer.hs
@@ -39,10 +39,11 @@ newAsyncDebouncer = Debouncer . asyncRegisterEvent <$> newVar Map.empty
 -- Events are run unmasked so it is up to the user of `registerEvent`
 -- to mask if required.
 asyncRegisterEvent :: (Eq k, Hashable k) => Var (HashMap k (Async ())) -> Seconds -> k -> IO () -> IO ()
-asyncRegisterEvent d 0 k fire = modifyVar_ d $ \m -> mask_ $ do
-    whenJust (Map.lookup k m) cancel
+asyncRegisterEvent d 0 k fire = do
+    modifyVar_ d $ \m -> mask_ $ do
+        whenJust (Map.lookup k m) cancel
+        pure $ Map.delete k m
     fire
-    pure $ Map.delete k m
 asyncRegisterEvent d delay k fire = modifyVar_ d $ \m -> mask_ $ do
     whenJust (Map.lookup k m) cancel
     a <- asyncWithUnmask $ \unmask -> unmask $ do

--- a/src/Development/IDE/Core/Debouncer.hs
+++ b/src/Development/IDE/Core/Debouncer.hs
@@ -39,6 +39,10 @@ newAsyncDebouncer = Debouncer . asyncRegisterEvent <$> newVar Map.empty
 -- Events are run unmasked so it is up to the user of `registerEvent`
 -- to mask if required.
 asyncRegisterEvent :: (Eq k, Hashable k) => Var (HashMap k (Async ())) -> Seconds -> k -> IO () -> IO ()
+asyncRegisterEvent d 0 k fire = modifyVar_ d $ \m -> mask_ $ do
+    whenJust (Map.lookup k m) cancel
+    fire
+    pure $ Map.delete k m
 asyncRegisterEvent d delay k fire = modifyVar_ d $ \m -> mask_ $ do
     whenJust (Map.lookup k m) cancel
     a <- asyncWithUnmask $ \unmask -> unmask $ do


### PR DESCRIPTION
The indirection caused by `async (sleep 0 >> fire)` was causing non-deterministic ordering of progress done messages and diagnostics, which makes the code actions benchmark experiment fail randomly.