### PR TITLE
Avoid excessive retypechecking of TH codebases

### DIFF
--- a/fmt.sh
+++ b/fmt.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -eou pipefail
-curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/run.sh | sh -s . --with-group=extra
+curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/run.sh | sh -s src exe bench/exe test/exe --with-group=extra

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -587,9 +587,6 @@ loadInterface session ms sourceMod regen = do
             -- nothing at all has changed. Stability is just
             -- the same check that make is doing for us in
             -- one-shot mode.
-            | not (mi_used_th x) || stable
+            | not (mi_used_th x) || SourceUnmodifiedAndStable == sourceMod
             -> return ([], Just $ HiFileResult ms x)
           (_reason, _) -> regen
-    where
-        -- TODO support stability
-        stable = False

--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -14,6 +14,7 @@ module Development.IDE.Core.RuleTypes(
 import           Control.DeepSeq
 import Data.Binary
 import           Development.IDE.Import.DependencyInformation
+import Development.IDE.GHC.Compat
 import Development.IDE.GHC.Util
 import           Data.Hashable
 import           Data.Typeable
@@ -21,12 +22,12 @@ import qualified Data.Set as S
 import           Development.Shake
 import           GHC.Generics                             (Generic)
 
-import           GHC
 import Module (InstalledUnitId)
-import HscTypes (CgGuts, Linkable, HomeModInfo, ModDetails)
+import HscTypes (hm_iface, CgGuts, Linkable, HomeModInfo, ModDetails)
 
 import           Development.IDE.Spans.Type
 import           Development.IDE.Import.FindImports (ArtifactsLocation)
+import Data.ByteString (ByteString)
 
 
 -- NOTATION
@@ -66,6 +67,15 @@ data HiFileResult = HiFileResult
     -- a reference to a typechecked module
     , hirModIface :: !ModIface
     }
+
+tmr_hiFileResult :: TcModuleResult -> HiFileResult
+tmr_hiFileResult tmr = HiFileResult modSummary modIface
+  where
+    modIface = hm_iface . tmrModInfo $ tmr
+    modSummary = tmrModSummary tmr
+
+hiFileFingerPrint :: HiFileResult -> ByteString
+hiFileFingerPrint = fingerprintToBS . getModuleHash . hirModIface
 
 instance NFData HiFileResult where
     rnf = rwhnf

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -704,7 +704,9 @@ getModIfaceRule = defineEarlyCutoff $ \GetModIface f -> do
             return (fp, ([], hiFile))
 #else
     tm <- use TypeCheck f
-    return ([], tmr_hiFileResult <$> tm)
+    let !hiFile = extractHiFileResult tm
+    let fp = hiFileFingerPrint <$> hiFile
+    return (fp, ([], tmr_hiFileResult <$> tm))
 #endif
 
 regenerateHiFile :: HscEnvEq -> NormalizedFilePath -> Action ([FileDiagnostic], Maybe HiFileResult)

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -651,7 +651,7 @@ isHiFileStableRule = define $ \IsHiFileStable f -> do
                 then pure SourceModified
                 else do
                     (fileImports, _) <- use_ GetLocatedImports f
-                    let imports = (fmap artifactFilePath) . snd <$> fileImports
+                    let imports = fmap artifactFilePath . snd <$> fileImports
                     deps <- uses_ IsHiFileStable (catMaybes imports)
                     pure $ if all (== SourceUnmodifiedAndStable) deps
                         then SourceUnmodifiedAndStable

--- a/src/Development/IDE/GHC/Orphans.hs
+++ b/src/Development/IDE/GHC/Orphans.hs
@@ -70,3 +70,8 @@ instance Show HieFile where
 
 instance NFData HieFile where
     rnf = rwhnf
+
+deriving instance Eq SourceModified
+deriving instance Show SourceModified
+instance NFData SourceModified where
+    rnf = rwhnf

--- a/test/data/TH/THA.hs
+++ b/test/data/TH/THA.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE TemplateHaskell #-}
+module THA where
+import Language.Haskell.TH
+
+th_a :: DecsQ
+th_a = [d| a = () |]

--- a/test/data/TH/THB.hs
+++ b/test/data/TH/THB.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE TemplateHaskell #-}
+module THB where
+import THA
+
+$th_a
+

--- a/test/data/TH/THC.hs
+++ b/test/data/TH/THC.hs
@@ -1,0 +1,5 @@
+module THC where
+import THB
+
+c ::()
+c = a

--- a/test/data/TH/hie.yaml
+++ b/test/data/TH/hie.yaml
@@ -1,0 +1,1 @@
+cradle: {direct: {arguments: ["-Wmissing-signatures", "-package template-haskell", "THA", "THB", "THC"]}}

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -56,7 +56,7 @@ main :: IO ()
 main = do
   -- We mess with env vars so run single-threaded.
   setEnv "TASTY_NUM_THREADS" "1" True
-  defaultMainWithRerun $ testGroup "GHCIDE"
+  defaultMainWithRerun $ testGroup "ghcide"
     [ testSession "open close" $ do
         doc <- createDoc "Testing.hs" "haskell" ""
         void (skipManyTill anyMessage message :: Session WorkDoneProgressCreateRequest)

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -51,12 +51,13 @@ import Test.Tasty.ExpectedFailure
 import Test.Tasty.Ingredients.Rerun
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
+import qualified Data.Text.IO as T
 
 main :: IO ()
 main = do
   -- We mess with env vars so run single-threaded.
   setEnv "TASTY_NUM_THREADS" "1" True
-  defaultMainWithRerun $ testGroup "HIE"
+  defaultMainWithRerun $ testGroup "GHCIDE"
     [ testSession "open close" $ do
         doc <- createDoc "Testing.hs" "haskell" ""
         void (skipManyTill anyMessage message :: Session WorkDoneProgressCreateRequest)
@@ -1675,7 +1676,42 @@ thTests =
         _ <- createDoc "A.hs" "haskell" sourceA
         _ <- createDoc "B.hs" "haskell" sourceB
         return ()
+    , thReloadingTest `xfail` "expect broken (#672)"
     ]
+
+-- | test that TH is reevaluated on typecheck
+thReloadingTest :: TestTree
+thReloadingTest = testCase "reloading-th-test" $ withoutStackEnv $ runWithExtraFiles "TH" $ \dir -> do
+    let aPath = dir </> "THA.hs"
+        bPath = dir </> "THB.hs"
+        cPath = dir </> "THC.hs"
+
+    aSource <- liftIO $ readFileUtf8 aPath --  th = [d|a :: ()|]
+    bSource <- liftIO $ readFileUtf8 bPath --  $th
+    cSource <- liftIO $ readFileUtf8 cPath --  c = a :: ()
+
+    adoc <- createDoc aPath "haskell" aSource
+    bdoc <- createDoc bPath "haskell" bSource
+    cdoc <- createDoc cPath "haskell" cSource
+
+    expectDiagnostics [("THB.hs", [(DsWarning, (4,0), "Top-level binding")])]
+
+    -- Change th from () to Bool
+    let aSource' = T.unlines $ init (T.lines aSource) ++ ["th_a = [d| a = False|]"]
+    changeDoc adoc [TextDocumentContentChangeEvent Nothing Nothing aSource']
+    -- generate an artificial warning to avoid timing out if the TH change does not propagate
+    changeDoc cdoc [TextDocumentContentChangeEvent Nothing Nothing $ cSource <> "\nfoo=()"]
+
+    -- Check that the change propagates to C
+    expectDiagnostics
+        [("THC.hs", [(DsError, (4, 4), "Couldn't match expected type '()' with actual type 'Bool'")])
+        ,("THC.hs", [(DsWarning, (6,0), "Top-level binding")])
+        ]
+
+    closeDoc adoc
+    closeDoc bdoc
+    closeDoc cdoc
+
 
 completionTests :: TestTree
 completionTests
@@ -2200,7 +2236,31 @@ ifaceTests = testGroup "Interface loading tests"
       ifaceErrorTest
     , ifaceErrorTest2
     , ifaceErrorTest3
+    , ifaceTHTest
     ]
+
+-- | test that TH reevaluates across interfaces
+ifaceTHTest :: TestTree
+ifaceTHTest = testCase "iface-th-test" $ withoutStackEnv $ runWithExtraFiles "TH" $ \dir -> do
+    let aPath = dir </> "THA.hs"
+        bPath = dir </> "THB.hs"
+        cPath = dir </> "THC.hs"
+
+    aSource <- liftIO $ readFileUtf8 aPath -- [TH] a :: ()
+    _bSource <- liftIO $ readFileUtf8 bPath -- a :: ()
+    cSource <- liftIO $ readFileUtf8 cPath -- c = a :: ()
+
+    cdoc <- createDoc cPath "haskell" cSource
+
+    -- Change [TH]a from () to Bool
+    liftIO $ T.writeFile aPath (T.unlines $ init (T.lines aSource) ++ ["th_a = [d| a = False|]"])
+
+    -- Check that the change propogates to C
+    changeDoc cdoc [TextDocumentContentChangeEvent Nothing Nothing cSource]
+    expectDiagnostics
+      [("THC.hs", [(DsError, (4, 4), "Couldn't match expected type '()' with actual type 'Bool'")])
+      ,("THB.hs", [(DsWarning, (4,0), "Top-level binding")])]
+    closeDoc cdoc
 
 ifaceErrorTest :: TestTree
 ifaceErrorTest = testCase "iface-error-test-1" $ withoutStackEnv $ runWithExtraFiles "recomp" $ \dir -> do
@@ -2440,9 +2500,9 @@ runInDir dir s = do
     conf = defaultConfig
       -- If you uncomment this you can see all logging
       -- which can be quite useful for debugging.
-      -- { logStdErr = True, logColor = False }
+    --   { logStdErr = True, logColor = False }
       -- If you really want to, you can also see all messages
-      -- { logMessages = True, logColor = False }
+    --   { logMessages = True, logColor = False }
 
 openTestDataDoc :: FilePath -> Session TextDocumentIdentifier
 openTestDataDoc path = do

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -51,7 +51,6 @@ import Test.Tasty.ExpectedFailure
 import Test.Tasty.Ingredients.Rerun
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
-import qualified Data.Text.IO as T
 
 main :: IO ()
 main = do
@@ -2253,7 +2252,7 @@ ifaceTHTest = testCase "iface-th-test" $ withoutStackEnv $ runWithExtraFiles "TH
     cdoc <- createDoc cPath "haskell" cSource
 
     -- Change [TH]a from () to Bool
-    liftIO $ T.writeFile aPath (T.unlines $ init (T.lines aSource) ++ ["th_a = [d| a = False|]"])
+    liftIO $ writeFileUTF8 aPath (unlines $ init (lines $ T.unpack aSource) ++ ["th_a = [d| a = False|]"])
 
     -- Check that the change propogates to C
     changeDoc cdoc [TextDocumentContentChangeEvent Nothing Nothing cSource]


### PR DESCRIPTION
This PR follows the plan outlined in #660 including tests. 

Our current benchmark example (Cabal)  doesn't include any example of TH, so the only thing visible in the benchmark results is that things do not regress too much: 

| version  |  name                       |  success |  samples |  startup            |  setup              |  experiment          |  maxResidency |
| -------- | --------------------------- | -------- | -------- | ------------------- | ------------------- | -------------------- | ------------- |
| upstream |  code actions               |  True    |  100     |  10.000944527000001 |  0.59697904         |  0.68091352          |  196MB        |
| HEAD     |  code actions               |  True    |  100     |  9.981281715000001  |  0.9265053580000001 |  0.905302617         |  204MB        |
| upstream |  code actions after edit    |  True    |  100     |  9.870548535000001  |  0.0                |  29.209360251000003  |  197MB        |
| HEAD     |  code actions after edit    |  True    |  100     |  10.058724974       |  0.0                |  31.147682330000002  |  205MB        |
| upstream |  completions after edit     |  True    |  100     |  10.079300106       |  0.0                |  38.186949398        |  173MB        |
| HEAD     |  completions after edit     |  True    |  100     |  10.005696135       |  0.0                |  41.423665788        |  183MB        |
| upstream |  documentSymbols after edit |  True    |  100     |  9.973052604000001  |  0.0                |  4.571069307         |  170MB        |
| HEAD     |  documentSymbols after edit |  True    |  100     |  10.009694254000001 |  0.0                |  4.464170808         |  170MB        |
| upstream |  edit                       |  True    |  100     |  10.684809285       |  0.0                |  27.757133392        |  168MB        |
| HEAD     |  edit                       |  True    |  100     |  10.892325944000001 |  0.0                |  29.814292458        |  172MB        |
| upstream |  getDefinition              |  True    |  100     |  10.52725915        |  0.0                |  0.8384268300000001  |  172MB        |
| HEAD     |  getDefinition              |  True    |  100     |  11.522601252000001 |  0.0                |  0.8449014170000001  |  171MB        |
| upstream |  hover                      |  True    |  100     |  10.000964431       |  0.0                |  0.441070864         |  170MB        |
| HEAD     |  hover                      |  True    |  100     |  9.916935132        |  0.0                |  0.48269071300000005 |  171MB        |
| upstream |  hover after edit           |  True    |  100     |  10.222695908       |  0.0                |  35.27605837         |  170MB        |
| HEAD     |  hover after edit           |  True    |  100     |  10.497113535       |  0.0                |  38.391144658        |  178MB        |
|          |                             |          |          |                     |                     |                      |               |

Full results in https://github.com/pepeiborra/ghcide/tree/TH-benchmarks/bench-hist

I also noticed that TH reloading is not happening when *not* using interface files, that is, when the TH is in a file of interest. Raised #672 and included a failing test here.