### PR TITLE
Fix spaninfo Haddocks for local modules

### DIFF
--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -468,7 +468,7 @@ getSpanInfoRule :: Rules ()
 getSpanInfoRule =
     define $ \GetSpanInfo file -> do
         tc <- use_ TypeCheck file
-        packageState <- hscEnv <$> use_ GhcSession file
+        packageState <- hscEnv <$> use_ GhcSessionDeps file
 
 -- When possible, rely on the haddocks embedded in our interface files
 -- This creates problems on ghc-lib, see comment on 'getDocumentationTryGhc'

--- a/test/data/hover/Bar.hs
+++ b/test/data/hover/Bar.hs
@@ -1,3 +1,4 @@
 module Bar (Bar(..)) where
 
+-- | Bar Haddock
 data Bar = Bar

--- a/test/data/hover/Foo.hs
+++ b/test/data/hover/Foo.hs
@@ -2,4 +2,5 @@ module Foo (Bar, foo) where
 
 import Bar
 
+-- | foo Haddock
 foo = Bar

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -1649,8 +1649,13 @@ findDefinitionAndHoverTests = let
   lstL43 = Position 47 12  ;  litL   = [ExpectHoverText ["[8391 :: Int, 6268]"]]
   outL45 = Position 49  3  ;  outSig = [ExpectHoverText ["outer", "Bool"], mkR 46 0 46 5]
   innL48 = Position 52  5  ;  innSig = [ExpectHoverText ["inner", "Char"], mkR 49 2 49 7]
-  imported = Position 56 13 ; importedSig = getDocUri "Foo.hs" >>= \foo -> return [ExpectHoverText ["foo", "Foo"], mkL foo 4 0 4 3]
-  reexported = Position 55 14 ; reexportedSig = getDocUri "Bar.hs" >>= \bar -> return [ExpectHoverText ["Bar", "Bar"], mkL bar 2 0 2 14]
+#if MIN_GHC_API_VERSION(8,6,0)
+  imported = Position 56 13 ; importedSig = getDocUri "Foo.hs" >>= \foo -> return [ExpectHoverText ["foo", "Foo", "Haddock"], mkL foo 5 0 5 3]
+  reexported = Position 55 14 ; reexportedSig = getDocUri "Bar.hs" >>= \bar -> return [ExpectHoverText ["Bar", "Bar", "Haddock"], mkL bar 3 0 3 14]
+#else
+  imported = Position 56 13 ; importedSig = getDocUri "Foo.hs" >>= \foo -> return [ExpectHoverText ["foo", "Foo"], mkL foo 5 0 5 3]
+  reexported = Position 55 14 ; reexportedSig = getDocUri "Bar.hs" >>= \bar -> return [ExpectHoverText ["Bar", "Bar"], mkL bar 3 0 3 14]
+#endif
   in
   mkFindTests
   --     def    hover  look       expect


### PR DESCRIPTION
The regression was introduced in #630.

I added `GhcSessionDeps` with the idea of reusing the typecheck GHC session
for computing the SpanInfo, instead of rebuilding it from scratch.

But I forgot to actually reuse it, or maybe the change got lost during the merge.