### PR TITLE
Performance improvements for GetSpanInfo

### DIFF
--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -26,6 +26,8 @@ module Development.IDE.Core.Compile
   , loadDepModule
   , loadModuleHome
   , setupFinderCache
+  , getDocsBatch
+  , lookupName
   ) where
 
 import Development.IDE.Core.RuleTypes
@@ -44,7 +46,7 @@ import Development.IDE.Types.Location
 import           DynamicLoading (initializePlugins)
 #endif
 
-import           GHC hiding (parseModule, typecheckModule)
+import           GHC hiding (parseModule, typecheckModule, lookupName)
 import qualified Parser
 import           Lexer
 #if MIN_GHC_API_VERSION(8,10,0)
@@ -61,7 +63,7 @@ import qualified HeaderInfo                     as Hdr
 import           HscMain                        (hscInteractive, hscSimplify)
 import           MkIface
 import           StringBuffer                   as SB
-import           TcRnMonad (initIfaceLoad, tcg_th_coreplugins)
+import           TcRnMonad (tct_id, TcTyThing(AGlobal, ATcId), initTc, initIfaceLoad, tcg_th_coreplugins)
 import           TcIface                        (typecheckIface)
 import           TidyPgm
 
@@ -81,6 +83,8 @@ import           System.IO.Extra
 import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
 import Exception (ExceptionMonad)
+import LoadIface (loadModuleInterface)
+import TcEnv (tcLookup)
 
 
 -- | Given a string buffer, return the string (after preprocessing) and the 'ParsedModule'.
@@ -621,3 +625,52 @@ loadInterface session ms sourceMod regen = do
             | not (mi_used_th x) || SourceUnmodifiedAndStable == sourceMod
             -> return ([], Just $ HiFileResult ms x)
           (_reason, _) -> regen
+
+-- | Non-interactive, batch version of 'InteractiveEval.getDocs'.
+--   The interactive paths create problems in ghc-lib builds
+--- and leads to fun errors like "Cannot continue after interface file error".
+getDocsBatch :: GhcMonad m
+        => Module  -- ^ a moudle where the names are in scope
+        -> [Name]
+        -> m [Either GetDocsFailure (Maybe HsDocString, Map.Map Int HsDocString)]
+getDocsBatch mod names = withSession $ \hsc_env -> liftIO $ do
+    ((_warns,errs), res) <- initTc hsc_env HsSrcFile False mod fakeSpan $ forM names $ \name ->
+        case nameModule_maybe name of
+            Nothing -> return (Left $ NameHasNoModule name)
+            Just mod -> do
+             ModIface { mi_doc_hdr = mb_doc_hdr
+                      , mi_decl_docs = DeclDocMap dmap
+                      , mi_arg_docs = ArgDocMap amap
+                      } <- loadModuleInterface "getModuleInterface" mod
+             if isNothing mb_doc_hdr && Map.null dmap && Map.null amap
+               then pure (Left (NoDocsInIface mod $ compiled name))
+               else pure (Right ( Map.lookup name dmap
+                                , Map.findWithDefault Map.empty name amap))
+    case res of
+        Just x -> return x
+        Nothing -> throwErrors errs
+  where
+    compiled n =
+      -- TODO: Find a more direct indicator.
+      case nameSrcLoc n of
+        RealSrcLoc {} -> False
+        UnhelpfulLoc {} -> True
+
+fakeSpan :: RealSrcSpan
+fakeSpan = realSrcLocSpan $ mkRealSrcLoc (fsLit "<ghcide>") 1 1
+
+-- | Non-interactive, batch version of 'InteractiveEval.lookupNames'.
+--   The interactive paths create problems in ghc-lib builds
+--- and leads to fun errors like "Cannot continue after interface file error".
+lookupName :: GhcMonad m
+           => Module -- ^ A module where the Names are in scope
+           -> Name
+           -> m (Maybe TyThing)
+lookupName mod name = withSession $ \hsc_env -> liftIO $ do
+    (_messages, res) <- initTc hsc_env HsSrcFile False mod fakeSpan $ do
+        tcthing <- tcLookup name
+        case tcthing of
+            AGlobal thing    -> return thing
+            ATcId{tct_id=id} -> return (AnId id)
+            _ -> panic "tcRnLookupName'"
+    return res

--- a/src/Development/IDE/GHC/Compat.hs
+++ b/src/Development/IDE/GHC/Compat.hs
@@ -83,6 +83,7 @@ import GHC hiding (
       VarPat,
       ModLocation,
       HasSrcSpan,
+      lookupName,
       getLoc
 #if MIN_GHC_API_VERSION(8,6,0)
     , getConArgs

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -36,6 +36,7 @@ import Coercion
 import Language.Haskell.LSP.Types
 import Language.Haskell.LSP.Types.Capabilities
 import qualified Language.Haskell.LSP.VFS as VFS
+import Development.IDE.Core.Compile
 import Development.IDE.Plugin.Completions.Types
 import Development.IDE.Spans.Documentation
 import Development.IDE.GHC.Compat as GHC
@@ -264,11 +265,11 @@ cacheDataProducer packageState tm deps = do
         case lookupTypeEnv typeEnv n of
           Just tt -> case safeTyThingId tt of
             Just var -> (\x -> ([x],mempty)) <$> varToCompl var
-            Nothing -> (\x -> ([x],mempty)) <$> toCompItem curModName n
-          Nothing -> (\x -> ([x],mempty)) <$> toCompItem curModName n
+            Nothing -> (\x -> ([x],mempty)) <$> toCompItem curMod curModName n
+          Nothing -> (\x -> ([x],mempty)) <$> toCompItem curMod curModName n
       getComplsForOne (GRE n _ False prov) =
         flip foldMapM (map is_decl prov) $ \spec -> do
-          compItem <- toCompItem (is_mod spec) n
+          compItem <- toCompItem curMod (is_mod spec) n
           let unqual
                 | is_qual spec = []
                 | otherwise = [compItem]
@@ -283,22 +284,15 @@ cacheDataProducer packageState tm deps = do
       varToCompl var = do
         let typ = Just $ varType var
             name = Var.varName var
-            label = T.pack $ showGhc name
         docs <- evalGhcEnv packageState $ getDocumentationTryGhc curMod (tm_parsed_module tm : deps) name
-        return $ mkNameCompItem name curMod typ Nothing docs
+        return $ mkNameCompItem name curModName typ Nothing docs
 
-      toCompItem :: ModuleName -> Name -> IO CompItem
-      toCompItem mn n = do
+      toCompItem :: Module -> ModuleName -> Name -> IO CompItem
+      toCompItem m mn n = do
         docs <- evalGhcEnv packageState $ getDocumentationTryGhc curMod (tm_parsed_module tm : deps) n
--- lookupName uses runInteractiveHsc, i.e., GHCi stuff which does not work with GHCi
--- and leads to fun errors like "Cannot continue after interface file error".
-#ifdef GHC_LIB
-        let ty = Right Nothing
-#else
         ty <- evalGhcEnv packageState $ catchSrcErrors "completion" $ do
-                name' <- lookupName n
+                name' <- lookupName m n
                 return $ name' >>= safeTyThingType
-#endif
         return $ mkNameCompItem n mn (either (const Nothing) id ty) Nothing docs
 
   (unquals,quals) <- getCompls rdrElts

--- a/src/Development/IDE/Spans/Calculate.hs
+++ b/src/Development/IDE/Spans/Calculate.hs
@@ -153,7 +153,7 @@ ieLNames (IEThingWith U n _ ns _) = ieLWrappedName n : map ieLWrappedName ns
 ieLNames _ = []
 
 -- | Get the name and type of a binding.
-getTypeLHsBind :: (GhcMonad m)
+getTypeLHsBind :: (Monad m)
                => OccEnv (HsBind GhcPs)
                -> LHsBind GhcTc
                -> m [(SpanSource, SrcSpan, Maybe Type)]
@@ -227,7 +227,7 @@ getTypeLHsExpr e = do
     isLitChild e = isLit e
 
 -- | Get the name and type of a pattern.
-getTypeLPat :: (GhcMonad m)
+getTypeLPat :: (Monad m)
             => Pat GhcTc
             -> m (Maybe (SpanSource, SrcSpan, Maybe Type))
 getTypeLPat pat = do
@@ -241,7 +241,7 @@ getTypeLPat pat = do
     getSpanSource _ = (NoSource, noSrcSpan)
 
 getLHsType
-    :: GhcMonad m
+    :: Monad m
     => LHsType GhcRn
     -> m [(SpanSource, SrcSpan)]
 getLHsType (L spn (HsTyVar U _ v)) = do

--- a/src/Development/IDE/Spans/Calculate.hs
+++ b/src/Development/IDE/Spans/Calculate.hs
@@ -74,6 +74,7 @@ getSpanInfo mods TcModuleResult{tmrModInfo, tmrModule = tcm@TypecheckedModule{..
          ts  = listifyAllSpans tm_renamed_source :: [LHsType GhcRn]
          allModules = tm_parsed_module : parsedDeps
          funBinds = funBindMap tm_parsed_module
+         thisMod = ms_mod $ pm_mod_summary tm_parsed_module
          modIface = hm_iface tmrModInfo
 
      -- Load this module in HPT to make its interface documentation available
@@ -102,7 +103,7 @@ getSpanInfo mods TcModuleResult{tmrModInfo, tmrModule = tcm@TypecheckedModule{..
 
     -- Batch extraction of Haddocks
      let names = nubOrd [ s | (Named s,_,_) <- sortedExprs ++ sortedConstraints]
-     docs <- Map.fromList . zip names <$> getDocumentationsTryGhc allModules names
+     docs <- Map.fromList . zip names <$> getDocumentationsTryGhc thisMod allModules names
      let withDocs (Named n, x, y) = (Named n, x, y, Map.findWithDefault emptySpanDoc n docs)
          withDocs (other, x, y) = (other, x, y, emptySpanDoc)
 

--- a/src/Development/IDE/Spans/Calculate.hs
+++ b/src/Development/IDE/Spans/Calculate.hs
@@ -24,11 +24,7 @@ import           FastString (mkFastString)
 import           OccName
 import           Development.IDE.Types.Location
 import           Development.IDE.Spans.Type
-#ifdef GHC_LIB
-import           Development.IDE.GHC.Error (zeroSpan)
-#else
 import           Development.IDE.GHC.Error (zeroSpan, catchSrcErrors)
-#endif
 import           Prelude hiding (mod)
 import           TcHsSyn
 import           Var

--- a/src/Development/IDE/Spans/Common.hs
+++ b/src/Development/IDE/Spans/Common.hs
@@ -47,14 +47,12 @@ listifyAllSpans' :: Typeable a
                    => TypecheckedSource -> [Pat a]
 listifyAllSpans' tcs = Data.Generics.listify (const True) tcs
 
-#ifndef GHC_LIB
 -- From haskell-ide-engine/src/Haskell/Ide/Engine/Support/HieExtras.hs
 safeTyThingType :: TyThing -> Maybe Type
 safeTyThingType thing
   | Just i <- safeTyThingId thing = Just (varType i)
 safeTyThingType (ATyCon tycon)    = Just (tyConKind tycon)
 safeTyThingType _                 = Nothing
-#endif
 
 safeTyThingId :: TyThing -> Maybe Id
 safeTyThingId (AnId i)                    = Just i

--- a/src/Development/IDE/Spans/Common.hs
+++ b/src/Development/IDE/Spans/Common.hs
@@ -6,9 +6,7 @@ module Development.IDE.Spans.Common (
 , listifyAllSpans
 , listifyAllSpans'
 , safeTyThingId
-#ifndef GHC_LIB
 , safeTyThingType
-#endif
 , SpanDoc(..)
 , emptySpanDoc
 , spanDocToMarkdown
@@ -25,9 +23,7 @@ import Outputable
 import DynFlags
 import ConLike
 import DataCon
-#ifndef GHC_LIB
 import Var
-#endif
 
 import qualified Documentation.Haddock.Parser as H
 import qualified Documentation.Haddock.Types as H

--- a/src/Development/IDE/Spans/Documentation.hs
+++ b/src/Development/IDE/Spans/Documentation.hs
@@ -16,9 +16,9 @@ import           Data.List.Extra
 import qualified Data.Map as M
 import           Data.Maybe
 import qualified Data.Text as T
+import           Development.IDE.Core.Compile
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Error
-import           Development.IDE.GHC.Util
 import           Development.IDE.Spans.Common
 import           FastString
 import           SrcLoc (RealLocated)


### PR DESCRIPTION
Avoiding duplicate work and batching ghc-api lookups for both `getDocs` and `lookupName` are the main sources of improvement. 

As a bonus I also removed usage of the GHCi code paths. Since there is no way for me to test if this fixes the ghc-lib issues, I'm happy to put the CPP pragmas back if that's preferred.

![edit](https://raw.githubusercontent.com/pepeiborra/ghcide/perf-spaninfo-benchmark/bench-hist/edit.svg)

Full benchmarks in: https://github.com/pepeiborra/ghcide/tree/perf-spaninfo-benchmark
