### PR TITLE
Update hie-bios to 0.6.1

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -518,7 +518,7 @@ setCacheDir logger prefix hscComponents comps dflags = do
 
 
 renderCradleError :: NormalizedFilePath -> CradleError -> FileDiagnostic
-renderCradleError nfp (CradleError _ec t) =
+renderCradleError nfp (CradleError _ _ec t) =
   ideErrorWithSource (Just "cradle") (Just DsError) nfp (T.unlines (map T.pack t))
 
 -- See Note [Multi Cradle Dependency Info]

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -251,7 +251,7 @@ executable ghcide
         hashable,
         haskell-lsp,
         haskell-lsp-types,
-        hie-bios >= 0.5.0 && < 0.6,
+        hie-bios >= 0.6.0 && < 0.7,
         ghcide,
         optparse-applicative,
         safe-exceptions,

--- a/stack-ghc-lib.yaml
+++ b/stack-ghc-lib.yaml
@@ -6,7 +6,7 @@ extra-deps:
 - haskell-lsp-types-0.22.0.0
 - lsp-test-0.11.0.2
 - extra-1.7.2
-- hie-bios-0.5.0
+- hie-bios-0.6.1
 - ghc-lib-parser-8.8.1
 - ghc-lib-8.8.1
 - fuzzy-0.1.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@ extra-deps:
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
 - lsp-test-0.11.0.2
-- hie-bios-0.5.0
+- hie-bios-0.6.1
 - fuzzy-0.1.0.0
 - regex-pcre-builtin-0.95.1.1.8.43
 - regex-base-0.94.0.0

--- a/stack810.yaml
+++ b/stack810.yaml
@@ -7,7 +7,7 @@ extra-deps:
 - haskell-lsp-types-0.22.0.0
 - lsp-test-0.11.0.2
 - ghc-check-0.5.0.1
-- hie-bios-0.5.0
+- hie-bios-0.6.1
 
 # not yet in stackage
 - Chart-diagrams-1.9.3

--- a/stack84.yaml
+++ b/stack84.yaml
@@ -11,7 +11,7 @@ extra-deps:
 - rope-utf16-splay-0.3.1.0
 - filepattern-0.1.1
 - js-dgtable-0.5.2
-- hie-bios-0.5.0
+- hie-bios-0.6.1
 - fuzzy-0.1.0.0
 - shake-0.18.5
 - time-compat-1.9.2.2

--- a/stack88.yaml
+++ b/stack88.yaml
@@ -6,7 +6,7 @@ extra-deps:
 - haskell-lsp-types-0.22.0.0
 - lsp-test-0.11.0.2
 - ghc-check-0.5.0.1
-- hie-bios-0.5.0
+- hie-bios-0.6.1
 - extra-1.7.2
 nix:
   packages: [zlib]


### PR DESCRIPTION
New features:
* Store dependencies in CradleError
* Add shell and dependency-shell attributes to bios cradle type
* Add getRuntimeGhcLibDir and getRuntimeGhcVersion functions through a new runGhcCmd API

Relevant bug - fixes:

* Detect implicit cabal cradle in the absence of cabal.project
* Dont resolve symlinks in cradle discovery
* Make Cradle dependencies for stack and cabal more reasonable
  * This ships with a known bug: stack lists cradle dependencies from sub-directories incorrectly
* Improve filtering of rts arguments from stack and cabal cradles
* Add cabal.project.local to cabal cradle dependencies