### PR TITLE
Populate ms_hs_date in GetModSummary rule

### DIFF
--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -84,8 +84,6 @@ import           System.IO.Extra
 import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
 import Exception (ExceptionMonad)
-import Data.Time (getCurrentTime)
-import System.IO.Error (isDoesNotExistError)
 import TcEnv (tcLookup)
 
 
@@ -460,10 +458,6 @@ getModSummaryFromImports
   -> Maybe SB.StringBuffer
   -> ExceptT [FileDiagnostic] m ModSummary
 getModSummaryFromImports fp contents = do
-    fileModTime <- liftIO $ getModificationTime fp `catch` \e ->
-        if isDoesNotExistError e
-            then getCurrentTime -- Virtual file case
-            else throwIO e
     (contents, dflags) <- preprocessor fp contents
     (srcImports, textualImports, L _ moduleName) <-
         ExceptT $ liftIO $ first (diagFromErrMsgs "parser" dflags) <$> GHC.getHeaderImports dflags contents fp fp
@@ -482,7 +476,7 @@ getModSummaryFromImports fp contents = do
 #if MIN_GHC_API_VERSION(8,8,0)
                 , ms_hie_date     = Nothing
 #endif
-                , ms_hs_date      = fileModTime
+                , ms_hs_date      = error "use GetModSummary instead of GetModSummaryWithoutTimestamps"
                 , ms_hsc_src      = sourceType
                 -- The contents are used by the GetModSummary rule
                 , ms_hspp_buf     = Just contents

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -85,6 +85,7 @@ import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
 import Exception (ExceptionMonad)
 import TcEnv (tcLookup)
+import Data.Time (UTCTime)
 
 
 -- | Given a string buffer, return the string (after preprocessing) and the 'ParsedModule'.
@@ -93,13 +94,14 @@ parseModule
     -> HscEnv
     -> [PackageName]
     -> FilePath
+    -> UTCTime
     -> Maybe SB.StringBuffer
     -> IO (IdeResult (StringBuffer, ParsedModule))
-parseModule IdeOptions{..} env comp_pkgs filename mbContents =
+parseModule IdeOptions{..} env comp_pkgs filename modTime mbContents =
     fmap (either (, Nothing) id) $
     evalGhcEnv env $ runExceptT $ do
         (contents, dflags) <- preprocessor filename mbContents
-        (diag, modu) <- parseFileContents optPreprocessor dflags comp_pkgs filename contents
+        (diag, modu) <- parseFileContents optPreprocessor dflags comp_pkgs filename modTime contents
         return (diag, Just (contents, modu))
 
 
@@ -409,11 +411,12 @@ getImportsParsed dflags (L loc parsed) = do
 getModSummaryFromBuffer
     :: GhcMonad m
     => FilePath
+    -> UTCTime
     -> DynFlags
     -> GHC.ParsedSource
     -> StringBuffer
     -> ExceptT [FileDiagnostic] m ModSummary
-getModSummaryFromBuffer fp dflags parsed contents = do
+getModSummaryFromBuffer fp modTime dflags parsed contents = do
   (modName, imports) <- liftEither $ getImportsParsed dflags parsed
 
   modLoc <- liftIO $ mkHomeModLocation dflags modName fp
@@ -421,11 +424,7 @@ getModSummaryFromBuffer fp dflags parsed contents = do
   return $ ModSummary
     { ms_mod          = mkModule (fsToUnitId unitId) modName
     , ms_location     = modLoc
-    , ms_hs_date      = error "Rules should not depend on ms_hs_date"
-        -- When we are working with a virtual file we do not have a file date.
-        -- To avoid silent issues where something is not processed because the date
-        -- has not changed, we make sure that things blow up if they depend on the
-        -- date.
+    , ms_hs_date      = modTime
     , ms_textual_imps = [imp | (False, imp) <- imports]
     , ms_hspp_file    = fp
     , ms_hspp_opts    = dflags
@@ -455,9 +454,10 @@ getModSummaryFromBuffer fp dflags parsed contents = do
 getModSummaryFromImports
   :: (HasDynFlags m, ExceptionMonad m, MonadIO m)
   => FilePath
+  -> UTCTime
   -> Maybe SB.StringBuffer
   -> ExceptT [FileDiagnostic] m ModSummary
-getModSummaryFromImports fp contents = do
+getModSummaryFromImports fp modTime contents = do
     (contents, dflags) <- preprocessor fp contents
     (srcImports, textualImports, L _ moduleName) <-
         ExceptT $ liftIO $ first (diagFromErrMsgs "parser" dflags) <$> GHC.getHeaderImports dflags contents fp fp
@@ -476,7 +476,7 @@ getModSummaryFromImports fp contents = do
 #if MIN_GHC_API_VERSION(8,8,0)
                 , ms_hie_date     = Nothing
 #endif
-                , ms_hs_date      = error "use GetModSummary instead of GetModSummaryWithoutTimestamps"
+                , ms_hs_date      = modTime
                 , ms_hsc_src      = sourceType
                 -- The contents are used by the GetModSummary rule
                 , ms_hspp_buf     = Just contents
@@ -533,9 +533,10 @@ parseFileContents
        -> DynFlags -- ^ flags to use
        -> [PackageName] -- ^ The package imports to ignore
        -> FilePath  -- ^ the filename (for source locations)
+       -> UTCTime   -- ^ the modification timestamp
        -> SB.StringBuffer -- ^ Haskell module source text (full Unicode is supported)
        -> ExceptT [FileDiagnostic] m ([FileDiagnostic], ParsedModule)
-parseFileContents customPreprocessor dflags comp_pkgs filename contents = do
+parseFileContents customPreprocessor dflags comp_pkgs filename modTime contents = do
    let loc  = mkRealSrcLoc (mkFastString filename) 1 1
    case unP Parser.parseModule (mkPState dflags contents loc) of
 #if MIN_GHC_API_VERSION(8,10,0)
@@ -569,7 +570,7 @@ parseFileContents customPreprocessor dflags comp_pkgs filename contents = do
                unless (null errs) $ throwE $ diagFromStrings "parser" DsError errs
                let parsed' = removePackageImports comp_pkgs parsed
                let preproc_warnings = diagFromStrings "parser" DsWarning preproc_warns
-               ms <- getModSummaryFromBuffer filename dflags parsed' contents
+               ms <- getModSummaryFromBuffer filename modTime dflags parsed' contents
                let pm =
                      ParsedModule {
                          pm_mod_summary = ms

--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -175,9 +175,13 @@ ideTryIOException fp act =
       (\(e :: IOException) -> ideErrorText fp $ T.pack $ show e)
       <$> try act
 
-
-getFileContents :: NormalizedFilePath -> Action (FileVersion, Maybe T.Text)
-getFileContents = use_ GetFileContents
+-- | Returns the modification time and the contents.
+--   For VFS paths, the modification time is the current time.
+getFileContents :: NormalizedFilePath -> Action (UTCTime, Maybe T.Text)
+getFileContents f = do
+    (fv, txt) <- use_ GetFileContents f
+    modTime <- maybe (liftIO getCurrentTime) return $ modificationTime fv
+    return (modTime, txt)
 
 fileStoreRules :: VFSHandle -> Rules ()
 fileStoreRules vfs = do

--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -10,6 +10,7 @@ module Development.IDE.Core.FileStore(
     setFileModified,
     setSomethingModified,
     fileStoreRules,
+    modificationTime,
     VFSHandle,
     makeVFSHandle,
     makeLSPVFSHandle
@@ -27,6 +28,8 @@ import           Development.Shake.Classes
 import           Control.Exception
 import           GHC.Generics
 import Data.Either.Extra
+import Data.Int (Int64)
+import Data.Time
 import System.IO.Error
 import qualified Data.ByteString.Char8 as BS
 import Development.IDE.Types.Diagnostics
@@ -36,9 +39,9 @@ import Development.IDE.Core.RuleTypes
 import qualified Data.Rope.UTF16 as Rope
 
 #ifdef mingw32_HOST_OS
-import Data.Time
 import qualified System.Directory as Dir
 #else
+import Data.Time.Clock.System (systemToUTCTime, SystemTime(MkSystemTime))
 import Foreign.Ptr
 import Foreign.C.String
 import Foreign.C.Types
@@ -124,7 +127,7 @@ getModificationTimeRule vfs =
     -- We might also want to try speeding this up on Windows at some point.
     -- TODO leverage DidChangeWatchedFile lsp notifications on clients that
     -- support them, as done for GetFileExists
-    getModTime :: FilePath -> IO (Int,Int)
+    getModTime :: FilePath -> IO (Int64, Int64)
     getModTime f =
 #ifdef mingw32_HOST_OS
         do time <- Dir.getModificationTime f
@@ -136,13 +139,22 @@ getModificationTimeRule vfs =
         alloca $ \secPtr ->
         alloca $ \nsecPtr -> do
             Posix.throwErrnoPathIfMinus1Retry_ "getmodtime" f $ c_getModTime f' secPtr nsecPtr
-            sec <- peek secPtr
-            nsec <- peek nsecPtr
-            pure (fromEnum sec, fromIntegral nsec)
+            CTime sec <- peek secPtr
+            CLong nsec <- peek nsecPtr
+            pure (sec, nsec)
 
 -- Sadly even unix’s getFileStatus + modificationTimeHiRes is still about twice as slow
 -- as doing the FFI call ourselves :(.
 foreign import ccall "getmodtime" c_getModTime :: CString -> Ptr CTime -> Ptr CLong -> IO Int
+#endif
+
+modificationTime :: FileVersion -> Maybe UTCTime
+modificationTime VFSVersion{} = Nothing
+modificationTime (ModificationTime large small) =
+#ifdef mingw32_HOST_OS
+    Just (UTCTime (ModifiedJulianDay $ fromIntegral large) (picosecondsToDiffTime $ fromIntegral small))
+#else
+    Just (systemToUTCTime $ MkSystemTime large (fromIntegral small))
 #endif
 
 getFileContentsRule :: VFSHandle -> Rules ()

--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -123,6 +123,10 @@ type instance RuleResult IsFileOfInterest = Bool
 -- without needing to parse the entire source
 type instance RuleResult GetModSummary = ModSummary
 
+-- | Generate a ModSummary with the timestamps elided,
+--   for more successful early cutoff
+type instance RuleResult GetModSummaryWithoutTimestamps = ModSummary
+
 data GetParsedModule = GetParsedModule
     deriving (Eq, Show, Typeable, Generic)
 instance Hashable GetParsedModule
@@ -205,6 +209,12 @@ data IsFileOfInterest = IsFileOfInterest
 instance Hashable IsFileOfInterest
 instance NFData   IsFileOfInterest
 instance Binary   IsFileOfInterest
+
+data GetModSummaryWithoutTimestamps = GetModSummaryWithoutTimestamps
+    deriving (Eq, Show, Typeable, Generic)
+instance Hashable GetModSummaryWithoutTimestamps
+instance NFData   GetModSummaryWithoutTimestamps
+instance Binary   GetModSummaryWithoutTimestamps
 
 data GetModSummary = GetModSummary
     deriving (Eq, Show, Typeable, Generic)

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -86,6 +86,7 @@ import Control.Exception
 import Control.Monad.State
 import FastString (FastString(uniq))
 import qualified HeaderInfo as Hdr
+import Data.Time (getCurrentTime, UTCTime(..))
 
 -- | This is useful for rules to convert rules that can only produce errors or
 -- a result into the more general IdeResult type that supports producing
@@ -165,7 +166,7 @@ getHieFile ide file mod = do
 
 getHomeHieFile :: NormalizedFilePath -> MaybeT IdeAction HieFile
 getHomeHieFile f = do
-  ms <- fst <$> useE GetModSummary f
+  ms <- fst <$> useE GetModSummaryWithoutTimestamps f
   let normal_hie_f = toNormalizedFilePath' hie_f
       hie_f = ml_hie_file $ ms_location ms
 
@@ -293,7 +294,7 @@ getParsedModuleDefinition packageState opt comp_pkgs file contents = do
 getLocatedImportsRule :: Rules ()
 getLocatedImportsRule =
     define $ \GetLocatedImports file -> do
-        ms <- use_ GetModSummary file
+        ms <- use_ GetModSummaryWithoutTimestamps file
         let imports = [(False, imp) | imp <- ms_textual_imps ms] ++ [(True, imp) | imp <- ms_srcimps ms]
         env_eq <- use_ GhcSession file
         let env = hscEnv env_eq
@@ -339,7 +340,7 @@ rawDependencyInformation fs = do
       -- If we have, just return its Id but don't update any of the state.
       -- Otherwise, we need to process its imports.
       checkAlreadyProcessed f $ do
-          al <- lift $ modSummaryToArtifactsLocation f <$> use_ GetModSummary f
+          al <- lift $ modSummaryToArtifactsLocation f <$> use_ GetModSummaryWithoutTimestamps f
           -- Get a fresh FilePathId for the new file
           fId <- getFreshFid al
           -- Adding an edge to the bootmap so we can make sure to
@@ -450,7 +451,7 @@ reportImportCyclesRule =
             where loc = srcSpanToLocation (getLoc imp)
                   fp = toNormalizedFilePath' $ srcSpanToFilename (getLoc imp)
           getModuleName file = do
-           ms <- use_ GetModSummary file
+           ms <- use_ GetModSummaryWithoutTimestamps file
            pure (moduleNameString . moduleName . ms_mod $ ms)
           showCycle mods  = T.intercalate ", " (map T.pack mods)
 
@@ -608,6 +609,8 @@ loadGhcSession = do
 ghcSessionDepsDefinition :: NormalizedFilePath -> Action (IdeResult HscEnvEq)
 ghcSessionDepsDefinition file = do
         hsc <- hscEnv <$> use_ GhcSession file
+        -- We do want the timestamps in the ModSummary for the interactive evaluation functions
+        -- (e.g. in the Eval plugin)
         (ms,_) <- useWithStale_ GetModSummary file
         (deps,_) <- useWithStale_ GetDependencies file
         let tdeps = transitiveModuleDeps deps
@@ -642,7 +645,7 @@ ghcSessionDepsDefinition file = do
 
 getModIfaceFromDiskRule :: Rules ()
 getModIfaceFromDiskRule = defineEarlyCutoff $ \GetModIfaceFromDisk f -> do
-  ms <- use_ GetModSummary f
+  ms <- use_ GetModSummaryWithoutTimestamps f
   (diags_session, mb_session) <- ghcSessionDepsDefinition f
   case mb_session of
       Nothing -> return (Nothing, (diags_session, Nothing))
@@ -657,7 +660,7 @@ getModIfaceFromDiskRule = defineEarlyCutoff $ \GetModIfaceFromDisk f -> do
 
 isHiFileStableRule :: Rules ()
 isHiFileStableRule = define $ \IsHiFileStable f -> do
-    ms <- use_ GetModSummary f
+    ms <- use_ GetModSummaryWithoutTimestamps f
     let hiFile = toNormalizedFilePath'
                 $ case ms_hsc_src ms of
                     HsBootFile -> addBootSuffix (ml_hi_file $ ms_location ms)
@@ -679,15 +682,41 @@ isHiFileStableRule = define $ \IsHiFileStable f -> do
     return ([], Just sourceModified)
 
 getModSummaryRule :: Rules ()
-getModSummaryRule = defineEarlyCutoff $ \GetModSummary f -> do
-    dflags <- hsc_dflags . hscEnv <$> use_ GhcSession f
-    (_, mFileContent) <- getFileContents f
-    modS <- liftIO $ evalWithDynFlags dflags $ runExceptT $
-        getModSummaryFromImports (fromNormalizedFilePath f) (textToStringBuffer <$> mFileContent)
-    case modS of
-        Right ms -> do
-            return ( Just (computeFingerprint f dflags ms), ([], Just ms))
-        Left diags -> return (Nothing, (diags, Nothing))
+getModSummaryRule = do
+    defineEarlyCutoff $ \GetModSummaryWithoutTimestamps f -> do
+        dflags <- hsc_dflags . hscEnv <$> use_ GhcSession f
+        (_, mFileContent) <- getFileContents f
+        let fp = fromNormalizedFilePath f
+        modS <- liftIO $ evalWithDynFlags dflags $ runExceptT $
+                getModSummaryFromImports fp (textToStringBuffer <$> mFileContent)
+        case modS of
+            Right ms -> do
+                let fingerPrint = hash (computeFingerprint f dflags ms)
+                return ( Just (BS.pack $ show fingerPrint) , ([], Just ms))
+            Left diags -> return (Nothing, (diags, Nothing))
+
+    defineEarlyCutoff $ \GetModSummary f -> do
+        ms <- use GetModSummaryWithoutTimestamps f
+        case ms of
+            Just msWithoutTimestamps -> do
+                isFileOfInterest <- use_ IsFileOfInterest f
+                let fp = fromNormalizedFilePath f
+                -- Get the modification time from the file system instead of Shake
+                --   * For non vfs this is correct, the 'FileVersion' times stored by Shake are opaque anyway
+                --   * For vfs the modification time is assumed to be the current time
+                fileModTime <- liftIO $ if isFileOfInterest
+                    then getCurrentTime
+                    else getModificationTime fp
+                let ms = msWithoutTimestamps
+                        { ms_hie_date = Nothing
+                        , ms_hs_date = fileModTime
+                        , ms_iface_date = Nothing
+                        }
+                dflags <- hsc_dflags . hscEnv <$> use_ GhcSession f
+                -- include the mod time in the fingerprint
+                let fp = BS.pack $ show $ hash (computeFingerprint f dflags ms, hashUTC fileModTime)
+                return (Just fp, ([], Just ms))
+            Nothing -> return (Nothing, ([], Nothing))
     where
         -- Compute a fingerprint from the contents of `ModSummary`,
         -- eliding the timestamps and other non relevant fields.
@@ -702,8 +731,9 @@ getModSummaryRule = defineEarlyCutoff $ \GetModSummary f -> do
                     )
                 fingerPrintImports = map (fmap uniq *** (moduleNameString . unLoc))
                 opts = Hdr.getOptions dflags (fromJust ms_hspp_buf) (fromNormalizedFilePath f)
-                fp = hash fingerPrint
-            in BS.pack (show fp)
+            in fingerPrint
+
+        hashUTC UTCTime{..} = (fromEnum utctDay, fromEnum utctDayTime)
 
 getModIfaceRule :: Rules ()
 getModIfaceRule = defineEarlyCutoff $ \GetModIface f -> do

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -645,8 +645,6 @@ ghcSessionDepsDefinition file = do
 
 getModIfaceFromDiskRule :: Rules ()
 getModIfaceFromDiskRule = defineEarlyCutoff $ \GetModIfaceFromDisk f -> do
-    -- We do want the timestamps in the ModSummary for the interactive evaluation functions
-    -- (e.g. in the Eval plugin)
   ms <- use_ GetModSummary f
   (diags_session, mb_session) <- ghcSessionDepsDefinition f
   case mb_session of

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -48,7 +48,7 @@ module Development.IDE.Core.Shake(
     sendEvent,
     ideLogger,
     actionLogger,
-    FileVersion(..), modificationTime,
+    FileVersion(..),
     Priority(..),
     updatePositionMapping,
     deleteValue,
@@ -114,6 +114,7 @@ import Data.IORef
 import NameCache
 import UniqSupply
 import PrelInfo
+import Data.Int (Int64)
 
 -- information we stash inside the shakeExtra field
 data ShakeExtras = ShakeExtras
@@ -632,7 +633,7 @@ newSession ShakeExtras{..} shakeDb systemActs userActs = do
 instantiateDelayedAction :: DelayedAction a -> IO (Barrier (Either SomeException a), DelayedActionInternal)
 instantiateDelayedAction (DelayedAction s p a) = do
   b <- newBarrier
-  let a' = do 
+  let a' = do
         -- work gets reenqueued when the Shake session is restarted
         -- it can happen that a work item finished just as it was reenqueud
         -- in that case, skipping the work is fine
@@ -1074,8 +1075,8 @@ type instance RuleResult GetModificationTime = FileVersion
 data FileVersion
     = VFSVersion !Int
     | ModificationTime
-      !Int   -- ^ Large unit (platform dependent, do not make assumptions)
-      !Int   -- ^ Small unit (platform dependent, do not make assumptions)
+      !Int64   -- ^ Large unit (platform dependent, do not make assumptions)
+      !Int64   -- ^ Small unit (platform dependent, do not make assumptions)
     deriving (Show, Generic)
 
 instance NFData FileVersion
@@ -1083,10 +1084,6 @@ instance NFData FileVersion
 vfsVersion :: FileVersion -> Maybe Int
 vfsVersion (VFSVersion i) = Just i
 vfsVersion ModificationTime{} = Nothing
-
-modificationTime :: FileVersion -> Maybe (Int, Int)
-modificationTime VFSVersion{} = Nothing
-modificationTime (ModificationTime large small) = Just (large, small)
 
 getDiagnosticsFromStore :: StoreItem -> [Diagnostic]
 getDiagnosticsFromStore (StoreItem _ diags) = concatMap SL.fromSortedList $ Map.elems diags

--- a/src/Development/IDE/Plugin/Completions.hs
+++ b/src/Development/IDE/Plugin/Completions.hs
@@ -58,7 +58,7 @@ produceCompletions = do
         -- For non local completions we avoid depending on the parsed module,
         -- synthetizing a fake module with an empty body from the buffer
         -- in the ModSummary, which preserves all the imports
-        ms <- fmap fst <$> useWithStale GetModSummary file
+        ms <- fmap fst <$> useWithStale GetModSummaryWithoutTimestamps file
         sess <- fmap fst <$> useWithStale GhcSessionDeps file
 
 -- When possible, rely on the haddocks embedded in our interface files


### PR DESCRIPTION
This is a straightforward fix that came up during https://github.com/haskell/haskell-language-server/pull/191