### PR TITLE
Obtain the GHC libdir at runtime

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -518,7 +518,7 @@ setCacheDir logger prefix hscComponents comps dflags = do
 
 
 renderCradleError :: NormalizedFilePath -> CradleError -> FileDiagnostic
-renderCradleError nfp (CradleError _ec t) =
+renderCradleError nfp (CradleError _ _ec t) =
   ideErrorWithSource (Just "cradle") (Just DsError) nfp (T.unlines (map T.pack t))
 
 -- See Note [Multi Cradle Dependency Info]

--- a/exe/Utils.hs
+++ b/exe/Utils.hs
@@ -1,9 +1,0 @@
-module Utils (getLibdir) where
-
-import qualified GHC.Paths
-import System.Environment
-import Data.Maybe
-
--- Set the GHC libdir to the nix libdir if it's present.
-getLibdir :: IO FilePath
-getLibdir = fromMaybe GHC.Paths.libdir <$> lookupEnv "NIX_GHC_LIBDIR"

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -251,7 +251,7 @@ executable ghcide
         hashable,
         haskell-lsp,
         haskell-lsp-types,
-        hie-bios >= 0.5.0 && < 0.6,
+        hie-bios >= 0.6.0 && < 0.7,
         ghcide,
         optparse-applicative,
         safe-exceptions,

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -259,7 +259,6 @@ executable ghcide
         text,
         unordered-containers
     other-modules:
-        Utils
         Arguments
         Paths_ghcide
 

--- a/stack-ghc-lib.yaml
+++ b/stack-ghc-lib.yaml
@@ -6,7 +6,7 @@ extra-deps:
 - haskell-lsp-types-0.22.0.0
 - lsp-test-0.11.0.2
 - extra-1.7.2
-- hie-bios-0.5.0
+- hie-bios-0.6.1
 - ghc-lib-parser-8.8.1
 - ghc-lib-8.8.1
 - fuzzy-0.1.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@ extra-deps:
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
 - lsp-test-0.11.0.2
-- hie-bios-0.5.0
+- hie-bios-0.6.1
 - fuzzy-0.1.0.0
 - regex-pcre-builtin-0.95.1.1.8.43
 - regex-base-0.94.0.0

--- a/stack810.yaml
+++ b/stack810.yaml
@@ -7,7 +7,7 @@ extra-deps:
 - haskell-lsp-types-0.22.0.0
 - lsp-test-0.11.0.2
 - ghc-check-0.5.0.1
-- hie-bios-0.5.0
+- hie-bios-0.6.1
 
 # not yet in stackage
 - Chart-diagrams-1.9.3

--- a/stack84.yaml
+++ b/stack84.yaml
@@ -11,7 +11,7 @@ extra-deps:
 - rope-utf16-splay-0.3.1.0
 - filepattern-0.1.1
 - js-dgtable-0.5.2
-- hie-bios-0.5.0
+- hie-bios-0.6.1
 - fuzzy-0.1.0.0
 - shake-0.18.5
 - time-compat-1.9.2.2

--- a/stack88.yaml
+++ b/stack88.yaml
@@ -6,7 +6,7 @@ extra-deps:
 - haskell-lsp-types-0.22.0.0
 - lsp-test-0.11.0.2
 - ghc-check-0.5.0.1
-- hie-bios-0.5.0
+- hie-bios-0.6.1
 - extra-1.7.2
 nix:
   packages: [zlib]

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -40,7 +40,8 @@ import Language.Haskell.LSP.VFS (applyChange)
 import Network.URI
 import System.Environment.Blank (getEnv, setEnv, unsetEnv)
 import System.FilePath
-import System.IO.Extra
+import System.IO.Extra hiding (withTempDir)
+import qualified System.IO.Extra
 import System.Directory
 import System.Exit (ExitCode(ExitSuccess))
 import System.Process.Extra (readCreateProcessWithExitCode, CreateProcess(cwd), proc)
@@ -1261,7 +1262,7 @@ addTypeAnnotationsToLiteralsTest = testGroup "add type annotations to literals t
                , ""
                , "import Debug.Trace"
                , ""
-               , "f a = traceShow \"debug\" a" 
+               , "f a = traceShow \"debug\" a"
                ])
     [ (DsWarning, (6, 6), "Defaulting the following constraint") ]
     "Add type annotation ‘[Char]’ to ‘\"debug\"’"
@@ -3001,3 +3002,11 @@ getWatchedFilesSubscriptionsUntil = do
             | Just RequestMessage{_params = RegistrationParams (List regs)} <- msgs
             , Registration _id WorkspaceDidChangeWatchedFiles args <- regs
             ]
+
+-- | Version of 'System.IO.Extra.withTempDir' that canonicalizes the path
+-- Which we need to do on macOS since the $TMPDIR can be in @/private/var@ or
+-- @/var@
+withTempDir :: (FilePath -> IO a) -> IO a
+withTempDir f = System.IO.Extra.withTempDir $ \dir -> do
+  dir' <- canonicalizePath dir
+  f dir'


### PR DESCRIPTION
#693 needs to be merged first

This replaces hardcoding the GHC libdir path with ghc-paths and instead
gets it at runtime through the hie-bios cradle. This means that the
ghcide binary should be a bit more distributable now, since it won't
rely on paths baked at compile time that are local to the machine it was
compiled on