### PR TITLE
Allow GHC plugins to be called with an updated StringBuffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ bench-temp/
 .shake/
 ghcide
 *.benchmark-gcStats
+tags

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -407,8 +407,9 @@ getModSummaryFromBuffer
     => FilePath
     -> DynFlags
     -> GHC.ParsedSource
+    -> StringBuffer
     -> ExceptT [FileDiagnostic] m ModSummary
-getModSummaryFromBuffer fp dflags parsed = do
+getModSummaryFromBuffer fp dflags parsed contents = do
   (modName, imports) <- liftEither $ getImportsParsed dflags parsed
 
   modLoc <- liftIO $ mkHomeModLocation dflags modName fp
@@ -424,7 +425,13 @@ getModSummaryFromBuffer fp dflags parsed = do
     , ms_textual_imps = [imp | (False, imp) <- imports]
     , ms_hspp_file    = fp
     , ms_hspp_opts    = dflags
-    , ms_hspp_buf     = Nothing
+        -- NOTE: It's /vital/ we set the 'StringBuffer' here, to give any
+        -- registered GHC plugins access to the /updated/ in-memory content
+        -- of a module being edited. Without this line, any plugin wishing to
+        -- parse an input module and perform operations on the /current/ state
+        -- of a file wouldn't work properly, as it would \"see\" a stale view of
+        -- the file (i.e., the on-disk content of the latter).
+    , ms_hspp_buf     = Just contents
 
     -- defaults:
     , ms_hsc_src      = sourceType
@@ -561,7 +568,7 @@ parseFileContents customPreprocessor dflags comp_pkgs filename contents = do
                unless (null errs) $ throwE $ diagFromStrings "parser" DsError errs
                let parsed' = removePackageImports comp_pkgs parsed
                let preproc_warnings = diagFromStrings "parser" DsWarning preproc_warns
-               ms <- getModSummaryFromBuffer filename dflags parsed'
+               ms <- getModSummaryFromBuffer filename dflags parsed' contents
                let pm =
                      ParsedModule {
                          pm_mod_summary = ms


### PR DESCRIPTION
While converting [LiquidHaskell into a plugin](https://github.com/ucsd-progsys/liquidhaskell/pull/1683), we tried to integrate it with `ghcide`. It has been a journey with some lumps and bumps, but eventually we succeeded (with proviso). The plugin itself requires the minimum version of GHC to be `8.10.1` (for technical reasons) and soon enough we discovered that plugins and `8.10.1` don't get along too well, mostly due to https://gitlab.haskell.org/ghc/ghc/-/issues/18070 (which was originally discovered as part of  #556).

However, I've tried building a custom `ghc` version (via Hadrian, as Leon Schoorl mentioned in that GHC ticket) and indeed got `ghcide` to _sort of_ work with the LH plugin. I say "sort of" because we were observing some strange behaviour where diagnostics would be emitted only _when saving the corresponding file_, and not in real time, as usual. This happened (in short) for two reasons:

* `ghcide` seems to _not_ be calling any other plugin "hook" than the `typecheckResultAction`. It doesn't do it _directly_,
   but rather indirectly as part of the GHC API call to `typecheckModule`. This means that plugins have only "one single place"
  where they can intercept the normal `ghcide` workflow and do something else;

* Crucially speaking, when `ghcide` was calling the `typecheckResultAction`, it was doing it with a _stale_ view of the file
  being checked. In other terms, plugins received an input `ModSummary` that virtually pointed to the _on disk_ snapshot of
  a file, and not the _in memory_ one that the user was editing (via its editor of choice).

However, a point could be made that **is `ghcide`'s responsibility to call any registered plugin with the same view of the world that `ghcide` also "sees", to ensure there is no mismatch between what users can do and that plugins can do**.

This patch fixes it:

![lh_ghcide](https://user-images.githubusercontent.com/442035/87291327-7103cb00-c4ff-11ea-9c23-a79b839a5980.gif)

While this works, it's also my first foray into `ghcide` hacking, so I have no clue whether or not this patch could add a severe overhead to the typechecking rule. If I understand correctly `getFileContents` caches the information, so in theory if the file doesn't change too often, this call is relatively cheap. Having said that, there might be better ways to achieve the same result I simply didn't think of.

## Other caveats

This fix relies, as most fixes in this space, on the delicate house of cards provided by the GHC API. It works for LH (that needs to re-parse the input module) because the `parseModule` function from the GHC API looks first at the `ms_hspp_buf` content, and only if that's `Nothing`, it re-parses a module. On top of that, we have no guarantees (in the types, that is) that somebody else won't override the `ms_hspp_buf` downstream, before calling `GHC.typecheckModule`.