### PR TITLE
Expect bench experiments to fail with Cabal

### DIFF
--- a/stack-ghc-lib.yaml
+++ b/stack-ghc-lib.yaml
@@ -24,3 +24,4 @@ flags:
 ghc-options:
   ghc-lib-parser: -O0
   ghc-lib: -O0
+  ghcide: -DSTACK

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,3 +18,6 @@ extra-deps:
 - extra-1.7.2
 nix:
   packages: [zlib]
+
+ghc-options:
+  ghcide: -DSTACK

--- a/stack810.yaml
+++ b/stack810.yaml
@@ -27,3 +27,6 @@ extra-deps:
 
 nix:
   packages: [zlib]
+
+ghc-options:
+  ghcide: -DSTACK

--- a/stack84.yaml
+++ b/stack84.yaml
@@ -36,3 +36,7 @@ extra-deps:
 
 nix:
   packages: [zlib]
+
+
+ghc-options:
+  ghcide: -DSTACK

--- a/stack88.yaml
+++ b/stack88.yaml
@@ -10,3 +10,6 @@ extra-deps:
 - extra-1.7.2
 nix:
   packages: [zlib]
+
+ghc-options:
+  ghcide: -DSTACK


### PR DESCRIPTION
Currently these tests assume stack and will fail when launched with `cabal test`. 
This change acknowledges that failure as expected