### PR TITLE
Relax upper bounds for GHC 8.10.1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,14 @@
 packages: .
+
+allow-newer:
+	active:base,
+	diagrams-contrib:base,
+	diagrams-core:base,
+	diagrams-lib:base,
+	diagrams-postscript:base,
+    diagrams-svg:base,
+	dual-tree:base,
+	force-layout:base,
+	monoid-extras:base,
+	statestack:base,
+	svg-builder:base

--- a/cabal.project
+++ b/cabal.project
@@ -6,7 +6,7 @@ allow-newer:
 	diagrams-core:base,
 	diagrams-lib:base,
 	diagrams-postscript:base,
-    diagrams-svg:base,
+  diagrams-svg:base,
 	dual-tree:base,
 	force-layout:base,
 	monoid-extras:base,


### PR DESCRIPTION
Fixes the `cabal.project` build in 8.10.1