### PR TITLE
Use Bios targets in FindImports

### DIFF
--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -300,11 +300,10 @@ getLocatedImportsRule =
         let imports = [(False, imp) | imp <- ms_textual_imps ms] ++ [(True, imp) | imp <- ms_srcimps ms]
         env_eq <- use_ GhcSession file
         let env = hscEnv env_eq
-        let import_dirs = envDeps env_eq
         let dflags = addRelativeImport file (moduleName $ ms_mod ms) $ hsc_dflags env
         opt <- getIdeOptions
         (diags, imports') <- fmap unzip $ forM imports $ \(isSource, (mbPkgName, modName)) -> do
-            diagOrImp <- locateModule dflags import_dirs (optExtensions opt) getFileExists modName mbPkgName isSource
+            diagOrImp <- locateModule dflags env_eq (optExtensions opt) getFileExists modName mbPkgName isSource
             case diagOrImp of
                 Left diags -> pure (diags, Left (modName, Nothing))
                 Right (FileImport path) -> pure ([], Left (modName, Just path))

--- a/src/Development/IDE/GHC/Util.hs
+++ b/src/Development/IDE/GHC/Util.hs
@@ -193,7 +193,7 @@ instance Eq HscEnvEq where
 
 instance NFData HscEnvEq where
   rnf (HscEnvEq a b c d) =
-      rnf (hashUnique a) `seq` b `seq` c `seq` rnf d `seq` ()
+      rnf (hashUnique a) `seq` b `seq` c `seq` rnf d
 
 instance Hashable HscEnvEq where
   hashWithSalt s = hashWithSalt s . envUnique


### PR DESCRIPTION
Do not return any module that doesn't belong to the targets set.
If the targets set is empty, then lift this restriction.

The file existence check is probably redundant but keeping it around for now.

Fixes #733 