### PR TITLE
Add code actions for disabling a warning in the current file

### DIFF
--- a/src/Development/IDE/GHC/Warnings.hs
+++ b/src/Development/IDE/GHC/Warnings.hs
@@ -12,6 +12,7 @@ import qualified           Data.Text as T
 import           Development.IDE.Types.Diagnostics
 import           Development.IDE.GHC.Error
 import           Language.Haskell.LSP.Types (NumberOrString (StringValue))
+import Data.Char
 
 
 -- | Take a GHC monadic action (e.g. @typecheckModule pm@ for some
@@ -39,6 +40,7 @@ attachReason wr d = d{_code = StringValue <$> showReason wr}
   where
     showReason = \case
         NoReason -> Nothing
-        Reason flag -> Just $ showT flag
-        ErrReason flag -> showT <$> flag
-    showT = T.pack . show
+        Reason flag -> showFlag flag
+        ErrReason flag -> showFlag =<< flag
+    showFlag = fmap (("-W" <>) . camelToHyphenCase) . T.stripPrefix "Opt_Warn" . T.pack . show
+    camelToHyphenCase = T.dropWhile (== '-') . T.concatMap (\c -> if isUpper c then "-" <> T.singleton (toLower c) else T.singleton c)

--- a/src/Development/IDE/GHC/Warnings.hs
+++ b/src/Development/IDE/GHC/Warnings.hs
@@ -3,6 +3,7 @@
 
 module Development.IDE.GHC.Warnings(withWarnings) where
 
+import Data.List
 import ErrUtils
 import GhcPlugins as GHC hiding (Var, (<>))
 
@@ -39,82 +40,8 @@ attachReason wr d = d{_code = StringValue <$> showReason wr}
   where
     showReason = \case
         NoReason -> Nothing
-        Reason flag -> Just $ showFlag flag
-        ErrReason flag -> showFlag <$> flag
+        Reason flag -> showFlag flag
+        ErrReason flag -> showFlag =<< flag
 
-showFlag :: WarningFlag -> T.Text
-showFlag f = "-W" <> case f of
-    Opt_WarnAllMissedSpecs -> "all-missed-specialisations"
-    Opt_WarnAlternativeLayoutRuleTransitional -> "alternative-layout-rule-transitional"
-    Opt_WarnAutoOrphans -> "auto-orphans"
-    Opt_WarnCPPUndef -> "cpp-undef"
-    Opt_WarnDeferredOutOfScopeVariables -> "deferred-out-of-scope-variables"
-    Opt_WarnDeferredTypeErrors -> "deferred-type-errors"
-    Opt_WarnDeprecatedFlags -> "deprecated-flags"
-    Opt_WarnDerivingTypeable -> "deriving-typeable"
-    Opt_WarnDodgyExports -> "dodgy-exports"
-    Opt_WarnDodgyForeignImports -> "dodgy-foreign-imports"
-    Opt_WarnDodgyImports -> "dodgy-imports"
-    Opt_WarnDuplicateConstraints -> "duplicate-constraints"
-    Opt_WarnDuplicateExports -> "duplicate-exports"
-    Opt_WarnEmptyEnumerations -> "empty-enumerations"
-    Opt_WarnHiShadows -> "hi-shadowing"
-    Opt_WarnIdentities -> "identities"
-    Opt_WarnImplicitKindVars -> "implicit-kind-vars"
-    Opt_WarnImplicitPrelude -> "implicit-prelude"
-    Opt_WarnInaccessibleCode -> "inaccessible-code"
-    Opt_WarnIncompletePatterns -> "incomplete-patterns"
-    Opt_WarnIncompletePatternsRecUpd -> "incomplete-record-updates"
-    Opt_WarnIncompleteUniPatterns -> "incomplete-uni-patterns"
-    Opt_WarnInlineRuleShadowing -> "inline-rule-shadowing"
-    Opt_WarnMissedExtraSharedLib -> "missed-extra-shared-lib"
-    Opt_WarnMissedSpecs -> "missed-specializations"
-    Opt_WarnMissingDerivingStrategies -> "missing-deriving-strategies"
-    Opt_WarnMissingExportedSignatures -> "missing-export-lists"
-    Opt_WarnMissingExportList -> "missing-exported-signatures"
-    Opt_WarnMissingFields -> "missing-fields"
-    Opt_WarnMissingHomeModules -> "missing-home-modules"
-    Opt_WarnMissingImportList -> "missing-import-lists"
-    Opt_WarnMissingLocalSignatures -> "missing-local-signatures"
-    Opt_WarnMissingMethods -> "missing-methods"
-    Opt_WarnMissingMonadFailInstances -> "missing-monadfail-instances"
-    Opt_WarnMissingPatternSynonymSignatures -> "missing-pattern-synonym-signatures"
-    Opt_WarnMissingSignatures -> "missing-signatures"
-    Opt_WarnMonomorphism -> "monomorphism-restriction"
-    Opt_WarnNameShadowing -> "name-shadowing"
-    Opt_WarnNonCanonicalMonadFailInstances -> "noncanonical-monadfail-instances"
-    Opt_WarnNonCanonicalMonadInstances -> "noncanonical-monad-instances"
-    Opt_WarnNonCanonicalMonoidInstances -> "noncanonical-monoid-instances"
-    Opt_WarnOrphans -> "orphans"
-    Opt_WarnOverflowedLiterals -> "overflowed-literals"
-    Opt_WarnOverlappingPatterns -> "overlapping-patterns"
-    Opt_WarnPartialFields -> "partial-fields"
-    Opt_WarnPartialTypeSignatures -> "partial-type-signatures"
-    Opt_WarnRedundantConstraints -> "redundant-constraints"
-    Opt_WarnSafe -> "safe"
-    Opt_WarnSemigroup -> "semigroup"
-    Opt_WarnSimplifiableClassConstraints -> "simplifiable-class-constraints"
-    Opt_WarnSpaceAfterBang -> "missing-space-after-bang"
-    Opt_WarnStarBinder -> "star-binder"
-    Opt_WarnStarIsType -> "star-is-type"
-    Opt_WarnTabs -> "tabs"
-    Opt_WarnTrustworthySafe -> "trustworthy-safe"
-    Opt_WarnTypeDefaults -> "type-defaults"
-    Opt_WarnTypedHoles -> "typed-holes"
-    Opt_WarnUnbangedStrictPatterns -> "unbanged-strict-patterns"
-    Opt_WarnUnrecognisedPragmas -> "unrecognised-pragmas"
-    Opt_WarnUnrecognisedWarningFlags -> "unrecognisedarning-flags"
-    Opt_WarnUnsafe -> "unsafe"
-    Opt_WarnUnsupportedCallingConventions -> "unsupported-calling-conventions"
-    Opt_WarnUnsupportedLlvmVersion -> "unsupported-llvm-version"
-    Opt_WarnUntickedPromotedConstructors -> "unticked-promoted-constructors"
-    Opt_WarnUnusedDoBind -> "unused-do-bind"
-    Opt_WarnUnusedForalls -> "unused-foralls"
-    Opt_WarnUnusedImports -> "unused-imports"
-    Opt_WarnUnusedLocalBinds -> "unused-local-binds"
-    Opt_WarnUnusedMatches -> "unused-matches"
-    Opt_WarnUnusedPatternBinds -> "unused-pattern-binds"
-    Opt_WarnUnusedTopBinds -> "unused-top-binds"
-    Opt_WarnUnusedTypePatterns -> "unused-type-patterns"
-    Opt_WarnWarningsDeprecations ->  "deprecations"
-    Opt_WarnWrongDoBind -> "wrong-do-bind"
+showFlag :: WarningFlag -> Maybe T.Text
+showFlag flag = ("-W" <>) . T.pack . flagSpecName <$> find ((== flag) . flagSpecFlag) wWarningFlags

--- a/src/Development/IDE/GHC/Warnings.hs
+++ b/src/Development/IDE/GHC/Warnings.hs
@@ -12,7 +12,6 @@ import qualified           Data.Text as T
 import           Development.IDE.Types.Diagnostics
 import           Development.IDE.GHC.Error
 import           Language.Haskell.LSP.Types (NumberOrString (StringValue))
-import Data.Char
 
 
 -- | Take a GHC monadic action (e.g. @typecheckModule pm@ for some
@@ -40,7 +39,82 @@ attachReason wr d = d{_code = StringValue <$> showReason wr}
   where
     showReason = \case
         NoReason -> Nothing
-        Reason flag -> showFlag flag
-        ErrReason flag -> showFlag =<< flag
-    showFlag = fmap (("-W" <>) . camelToHyphenCase) . T.stripPrefix "Opt_Warn" . T.pack . show
-    camelToHyphenCase = T.dropWhile (== '-') . T.concatMap (\c -> if isUpper c then "-" <> T.singleton (toLower c) else T.singleton c)
+        Reason flag -> Just $ showFlag flag
+        ErrReason flag -> showFlag <$> flag
+
+showFlag :: WarningFlag -> T.Text
+showFlag f = "-W" <> case f of
+    Opt_WarnAllMissedSpecs -> "all-missed-specialisations"
+    Opt_WarnAlternativeLayoutRuleTransitional -> "alternative-layout-rule-transitional"
+    Opt_WarnAutoOrphans -> "auto-orphans"
+    Opt_WarnCPPUndef -> "cpp-undef"
+    Opt_WarnDeferredOutOfScopeVariables -> "deferred-out-of-scope-variables"
+    Opt_WarnDeferredTypeErrors -> "deferred-type-errors"
+    Opt_WarnDeprecatedFlags -> "deprecated-flags"
+    Opt_WarnDerivingTypeable -> "deriving-typeable"
+    Opt_WarnDodgyExports -> "dodgy-exports"
+    Opt_WarnDodgyForeignImports -> "dodgy-foreign-imports"
+    Opt_WarnDodgyImports -> "dodgy-imports"
+    Opt_WarnDuplicateConstraints -> "duplicate-constraints"
+    Opt_WarnDuplicateExports -> "duplicate-exports"
+    Opt_WarnEmptyEnumerations -> "empty-enumerations"
+    Opt_WarnHiShadows -> "hi-shadowing"
+    Opt_WarnIdentities -> "identities"
+    Opt_WarnImplicitKindVars -> "implicit-kind-vars"
+    Opt_WarnImplicitPrelude -> "implicit-prelude"
+    Opt_WarnInaccessibleCode -> "inaccessible-code"
+    Opt_WarnIncompletePatterns -> "incomplete-patterns"
+    Opt_WarnIncompletePatternsRecUpd -> "incomplete-record-updates"
+    Opt_WarnIncompleteUniPatterns -> "incomplete-uni-patterns"
+    Opt_WarnInlineRuleShadowing -> "inline-rule-shadowing"
+    Opt_WarnMissedExtraSharedLib -> "missed-extra-shared-lib"
+    Opt_WarnMissedSpecs -> "missed-specializations"
+    Opt_WarnMissingDerivingStrategies -> "missing-deriving-strategies"
+    Opt_WarnMissingExportedSignatures -> "missing-export-lists"
+    Opt_WarnMissingExportList -> "missing-exported-signatures"
+    Opt_WarnMissingFields -> "missing-fields"
+    Opt_WarnMissingHomeModules -> "missing-home-modules"
+    Opt_WarnMissingImportList -> "missing-import-lists"
+    Opt_WarnMissingLocalSignatures -> "missing-local-signatures"
+    Opt_WarnMissingMethods -> "missing-methods"
+    Opt_WarnMissingMonadFailInstances -> "missing-monadfail-instances"
+    Opt_WarnMissingPatternSynonymSignatures -> "missing-pattern-synonym-signatures"
+    Opt_WarnMissingSignatures -> "missing-signatures"
+    Opt_WarnMonomorphism -> "monomorphism-restriction"
+    Opt_WarnNameShadowing -> "name-shadowing"
+    Opt_WarnNonCanonicalMonadFailInstances -> "noncanonical-monadfail-instances"
+    Opt_WarnNonCanonicalMonadInstances -> "noncanonical-monad-instances"
+    Opt_WarnNonCanonicalMonoidInstances -> "noncanonical-monoid-instances"
+    Opt_WarnOrphans -> "orphans"
+    Opt_WarnOverflowedLiterals -> "overflowed-literals"
+    Opt_WarnOverlappingPatterns -> "overlapping-patterns"
+    Opt_WarnPartialFields -> "partial-fields"
+    Opt_WarnPartialTypeSignatures -> "partial-type-signatures"
+    Opt_WarnRedundantConstraints -> "redundant-constraints"
+    Opt_WarnSafe -> "safe"
+    Opt_WarnSemigroup -> "semigroup"
+    Opt_WarnSimplifiableClassConstraints -> "simplifiable-class-constraints"
+    Opt_WarnSpaceAfterBang -> "missing-space-after-bang"
+    Opt_WarnStarBinder -> "star-binder"
+    Opt_WarnStarIsType -> "star-is-type"
+    Opt_WarnTabs -> "tabs"
+    Opt_WarnTrustworthySafe -> "trustworthy-safe"
+    Opt_WarnTypeDefaults -> "type-defaults"
+    Opt_WarnTypedHoles -> "typed-holes"
+    Opt_WarnUnbangedStrictPatterns -> "unbanged-strict-patterns"
+    Opt_WarnUnrecognisedPragmas -> "unrecognised-pragmas"
+    Opt_WarnUnrecognisedWarningFlags -> "unrecognisedarning-flags"
+    Opt_WarnUnsafe -> "unsafe"
+    Opt_WarnUnsupportedCallingConventions -> "unsupported-calling-conventions"
+    Opt_WarnUnsupportedLlvmVersion -> "unsupported-llvm-version"
+    Opt_WarnUntickedPromotedConstructors -> "unticked-promoted-constructors"
+    Opt_WarnUnusedDoBind -> "unused-do-bind"
+    Opt_WarnUnusedForalls -> "unused-foralls"
+    Opt_WarnUnusedImports -> "unused-imports"
+    Opt_WarnUnusedLocalBinds -> "unused-local-binds"
+    Opt_WarnUnusedMatches -> "unused-matches"
+    Opt_WarnUnusedPatternBinds -> "unused-pattern-binds"
+    Opt_WarnUnusedTopBinds -> "unused-top-binds"
+    Opt_WarnUnusedTypePatterns -> "unused-type-patterns"
+    Opt_WarnWarningsDeprecations ->  "deprecations"
+    Opt_WarnWrongDoBind -> "wrong-do-bind"

--- a/src/Development/IDE/Plugin/CodeAction.hs
+++ b/src/Development/IDE/Plugin/CodeAction.hs
@@ -163,24 +163,23 @@ suggestAction packageExports ideOptions parsedModule text diag = concat
     , suggestReplaceIdentifier text diag
     , removeRedundantConstraints text diag
     , suggestAddTypeAnnotationToSatisfyContraints text diag
-    , suggestDisableWarning diag
     ] ++ concat
     [  suggestConstraint pm text diag
     ++ suggestNewDefinition ideOptions pm text diag
     ++ suggestNewImport packageExports pm diag
     ++ suggestDeleteUnusedBinding pm text diag
     ++ suggestExportUnusedTopBinding text pm diag
+    ++ suggestDisableWarning pm text diag
     | Just pm <- [parsedModule]
     ] ++
     suggestFillHole diag                   -- Lowest priority
 
-suggestDisableWarning :: Diagnostic -> [(T.Text, [TextEdit])]
-suggestDisableWarning Diagnostic{..}
+suggestDisableWarning :: ParsedModule -> Maybe T.Text -> Diagnostic -> [(T.Text, [TextEdit])]
+suggestDisableWarning pm contents Diagnostic{..}
     | Just (StringValue (T.stripPrefix "-W" -> Just w)) <- _code =
         pure
             ( "Disable \"" <> w <> "\" warnings"
-            , [TextEdit (Range (Position 0 0) (Position 0 0)) $ "{-# OPTIONS_GHC -Wno-" <> w <> " #-}\n"]
-
+            , [TextEdit (endOfModuleHeader pm contents) $ "{-# OPTIONS_GHC -Wno-" <> w <> " #-}\n"]
             )
     | otherwise = []
 
@@ -978,8 +977,8 @@ extractQualifiedModuleName :: T.Text -> Maybe T.Text
 extractQualifiedModuleName x
   | Just [m] <- matchRegexUnifySpaces x "module named [^‘]*‘([^’]*)’"
   = Just m
-  | otherwise 
-  = Nothing 
+  | otherwise
+  = Nothing
 
 -------------------------------------------------------------------------------------------------
 
@@ -1185,3 +1184,17 @@ renderIdentInfo :: IdentInfo -> T.Text
 renderIdentInfo IdentInfo {parent, rendered}
   | Just p <- parent = p <> "(" <> rendered <> ")"
   | otherwise        = rendered
+
+-- | Find the first non-blank line before the first of (module name / imports / declarations).
+-- Useful for inserting pragmas.
+endOfModuleHeader :: ParsedModule -> Maybe T.Text -> Range
+endOfModuleHeader pm contents =
+    let mod = unLoc $ pm_parsed_source pm
+        modNameLoc = getLoc <$> hsmodName mod
+        firstImportLoc = getLoc <$> listToMaybe (hsmodImports mod)
+        firstDeclLoc = getLoc <$> listToMaybe (hsmodDecls mod)
+        line = fromMaybe 0 $ firstNonBlankBefore . _line . _start =<< srcSpanToRange =<<
+            modNameLoc <|> firstImportLoc <|> firstDeclLoc
+        firstNonBlankBefore n = (n -) . fromMaybe 0 . findIndex (not . T.null) . reverse . take n . T.lines <$> contents
+        loc = Position line 0
+     in Range loc loc

--- a/src/Development/IDE/Plugin/CodeAction.hs
+++ b/src/Development/IDE/Plugin/CodeAction.hs
@@ -176,15 +176,13 @@ suggestAction packageExports ideOptions parsedModule text diag = concat
 
 suggestDisableWarning :: Diagnostic -> [(T.Text, [TextEdit])]
 suggestDisableWarning Diagnostic{..}
-    | Just (StringValue (showFlag -> Just w)) <- _code =
+    | Just (StringValue (T.stripPrefix "-W" -> Just w)) <- _code =
         pure
             ( "Disable \"" <> w <> "\" warnings"
             , [TextEdit (Range (Position 0 0) (Position 0 0)) $ "{-# OPTIONS_GHC -Wno-" <> w <> " #-}\n"]
+
             )
     | otherwise = []
-  where
-    showFlag = fmap camelToHyphenCase . T.stripPrefix "Opt_Warn"
-    camelToHyphenCase = T.dropWhile (== '-') . T.concatMap (\c -> if isUpper c then "-" <> T.singleton (toLower c) else T.singleton c)
 
 suggestRemoveRedundantImport :: ParsedModule -> Maybe T.Text -> Diagnostic -> [(T.Text, [TextEdit])]
 suggestRemoveRedundantImport ParsedModule{pm_parsed_source = L _  HsModule{hsmodImports}} contents Diagnostic{_range=_range,..}

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -856,7 +856,7 @@ removeImportTests = testGroup "remove import actions"
             ]
       docB <- createDoc "ModuleB.hs" "haskell" contentB
       _ <- waitForDiagnostics
-      [CACodeAction action@CodeAction { _title = actionTitle }, _]
+      [_, CACodeAction action@CodeAction { _title = actionTitle }, _]
           <- getCodeActions docB (Range (Position 2 0) (Position 2 5))
       liftIO $ "Remove import" @=? actionTitle
       executeCodeAction action
@@ -882,7 +882,7 @@ removeImportTests = testGroup "remove import actions"
             ]
       docB <- createDoc "ModuleB.hs" "haskell" contentB
       _ <- waitForDiagnostics
-      [CACodeAction action@CodeAction { _title = actionTitle }, _]
+      [_, CACodeAction action@CodeAction { _title = actionTitle }, _]
           <- getCodeActions docB (Range (Position 2 0) (Position 2 5))
       liftIO $ "Remove import" @=? actionTitle
       executeCodeAction action
@@ -911,7 +911,7 @@ removeImportTests = testGroup "remove import actions"
             ]
       docB <- createDoc "ModuleB.hs" "haskell" contentB
       _ <- waitForDiagnostics
-      [CACodeAction action@CodeAction { _title = actionTitle }, _]
+      [_, CACodeAction action@CodeAction { _title = actionTitle }, _]
           <- getCodeActions docB (Range (Position 2 0) (Position 2 5))
       liftIO $ "Remove stuffA, stuffC from import" @=? actionTitle
       executeCodeAction action
@@ -940,7 +940,7 @@ removeImportTests = testGroup "remove import actions"
             ]
       docB <- createDoc "ModuleB.hs" "haskell" contentB
       _ <- waitForDiagnostics
-      [CACodeAction action@CodeAction { _title = actionTitle }, _]
+      [_, CACodeAction action@CodeAction { _title = actionTitle }, _]
           <- getCodeActions docB (Range (Position 2 0) (Position 2 5))
       liftIO $ "Remove !!, <?> from import" @=? actionTitle
       executeCodeAction action
@@ -968,7 +968,7 @@ removeImportTests = testGroup "remove import actions"
             ]
       docB <- createDoc "ModuleB.hs" "haskell" contentB
       _ <- waitForDiagnostics
-      [CACodeAction action@CodeAction { _title = actionTitle }, _]
+      [_, CACodeAction action@CodeAction { _title = actionTitle }, _]
           <- getCodeActions docB (Range (Position 2 0) (Position 2 5))
       liftIO $ "Remove A from import" @=? actionTitle
       executeCodeAction action
@@ -995,7 +995,7 @@ removeImportTests = testGroup "remove import actions"
             ]
       docB <- createDoc "ModuleB.hs" "haskell" contentB
       _ <- waitForDiagnostics
-      [CACodeAction action@CodeAction { _title = actionTitle }, _]
+      [_, CACodeAction action@CodeAction { _title = actionTitle }, _]
           <- getCodeActions docB (Range (Position 2 0) (Position 2 5))
       liftIO $ "Remove A, E, F from import" @=? actionTitle
       executeCodeAction action
@@ -1019,7 +1019,7 @@ removeImportTests = testGroup "remove import actions"
             ]
       docB <- createDoc "ModuleB.hs" "haskell" contentB
       _ <- waitForDiagnostics
-      [CACodeAction action@CodeAction { _title = actionTitle }, _]
+      [_, CACodeAction action@CodeAction { _title = actionTitle }, _]
           <- getCodeActions docB (Range (Position 2 0) (Position 2 5))
       liftIO $ "Remove import" @=? actionTitle
       executeCodeAction action
@@ -1044,7 +1044,7 @@ removeImportTests = testGroup "remove import actions"
             ]
       doc <- createDoc "ModuleC.hs" "haskell" content
       _ <- waitForDiagnostics
-      [_, _, _, _, CACodeAction action@CodeAction { _title = actionTitle }]
+      [_, _, _, _, _, _, _, _, CACodeAction action@CodeAction { _title = actionTitle }]
           <- getCodeActions doc (Range (Position 2 0) (Position 2 5))
       liftIO $ "Remove all redundant imports" @=? actionTitle
       executeCodeAction action
@@ -2014,7 +2014,7 @@ removeRedundantConstraintsTests = let
     doc <- createDoc "Testing.hs" "haskell" code
     _ <- waitForDiagnostics
     actionsOrCommands <- getCodeActions doc (Range (Position 4 0) (Position 4 maxBound))
-    liftIO $ assertBool "Found some actions" (null actionsOrCommands)
+    liftIO $ assertBool "Found some actions" $ length actionsOrCommands == 1
 
   in testGroup "remove redundant function constraints"
   [ check
@@ -3808,7 +3808,10 @@ asyncTests = testGroup "async"
               ]
             void waitForDiagnostics
             actions <- getCodeActions doc (Range (Position 1 0) (Position 1 0))
-            liftIO $ [ _title | CACodeAction CodeAction{_title} <- actions] @=? ["add signature: foo :: a -> a"]
+            liftIO $ [ _title | CACodeAction CodeAction{_title} <- actions] @?=
+              [ "add signature: foo :: a -> a"
+              , "Disable \"missing-signatures\" warnings"
+              ]
     , testSession "request" $ do
             -- Execute a custom request that will block for 1000 seconds
             void $ sendRequest (CustomClientMethod "test") $ BlockSeconds 1000
@@ -3819,7 +3822,10 @@ asyncTests = testGroup "async"
               ]
             void waitForDiagnostics
             actions <- getCodeActions doc (Range (Position 0 0) (Position 0 0))
-            liftIO $ [ _title | CACodeAction CodeAction{_title} <- actions] @=? ["add signature: foo :: a -> a"]
+            liftIO $ [ _title | CACodeAction CodeAction{_title} <- actions] @?=
+              ["add signature: foo :: a -> a"
+              , "Disable \"missing-signatures\" warnings"
+              ]
     ]
 
 


### PR DESCRIPTION
This is a little ugly - we need some way to keep track of the [WarningFlag](https://hackage.haskell.org/package/ghc-8.10.1/docs/DynFlags.html#t:WarningFlag), so we store it as a string in the (previously unused by Ghcide) `_code` field of [Diagnostic](https://hackage.haskell.org/package/haskell-lsp-types-0.23.0.0/docs/Language-Haskell-LSP-Types.html#t:Diagnostic). I'm open to a better way.

Closes haskell/haskell-language-server#571.